### PR TITLE
Remove duplicated function and unify it in compat

### DIFF
--- a/bears/js/JSComplexityBear.py
+++ b/bears/js/JSComplexityBear.py
@@ -3,15 +3,9 @@ import re
 
 from coalib.bearlib.abstractions.Linter import linter
 from coalib.bears.requirements.NpmRequirement import NpmRequirement
+from coalib.misc.Compatibility import JSONDecodeError
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.results.Result import Result
-
-
-def get_available_decodeerror():
-    try:
-        return json.decoder.JSONDecodeError
-    except AttributeError:  # Python 3.4 does not have JSONDecodeError there
-        return ValueError
 
 
 @linter(executable='cr')
@@ -20,7 +14,6 @@ class JSComplexityBear:
     Calculates cyclomatic complexity using ``cr``, the command line utility
     provided by the NodeJS module ``complexity-report``.
     """
-    DecodeError = get_available_decodeerror()
 
     LANGUAGES = {"JavaScript"}
     REQUIREMENTS = {NpmRequirement('complexity-report', '2.0.0-alpha')}
@@ -42,7 +35,7 @@ class JSComplexityBear:
         if output:
             try:
                 output = json.loads(output)
-            except self.DecodeError:
+            except JSONDecodeError:
                 output_regex = (r'Fatal error \[getReports\]: .+: '
                                 r'Line (?P<line>\d+): (?P<message>.*)')
                 for match in re.finditer(output_regex, output):

--- a/bears/js/JSONFormatBear.py
+++ b/bears/js/JSONFormatBear.py
@@ -1,13 +1,13 @@
 import json
 from collections import OrderedDict
 
+from coala_utils.param_convertion import negate
 from coalib.bearlib import deprecate_settings
 from coalib.bearlib.spacing.SpacingHelper import SpacingHelper
 from coalib.bears.LocalBear import LocalBear
 from coalib.misc.Compatibility import JSONDecodeError
 from coalib.results.Diff import Diff
 from coalib.results.Result import Result
-from coala_utils.param_convertion import negate
 
 
 class JSONFormatBear(LocalBear):

--- a/bears/js/JSONFormatBear.py
+++ b/bears/js/JSONFormatBear.py
@@ -4,20 +4,13 @@ from collections import OrderedDict
 from coalib.bearlib import deprecate_settings
 from coalib.bearlib.spacing.SpacingHelper import SpacingHelper
 from coalib.bears.LocalBear import LocalBear
+from coalib.misc.Compatibility import JSONDecodeError
 from coalib.results.Diff import Diff
 from coalib.results.Result import Result
 from coala_utils.param_convertion import negate
 
 
-def get_available_decodeerror():
-    try:
-        return json.decoder.JSONDecodeError
-    except AttributeError:  # Python 3.4 does not have JSONDecodeError there
-        return ValueError
-
-
 class JSONFormatBear(LocalBear):
-    DecodeError = get_available_decodeerror()
 
     LANGUAGES = {"JSON"}
     AUTHORS = {'The coala developers'}
@@ -42,7 +35,7 @@ class JSONFormatBear(LocalBear):
         try:
             json_content = json.loads(''.join(file),
                                       object_pairs_hook=OrderedDict)
-        except self.DecodeError as err:
+        except JSONDecodeError as err:
             yield Result.from_values(
                 self,
                 "This file does not contain parsable JSON. " + repr(str(err)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Use >= for development versions so that source builds always work
-coala>=0.8.1
+coala>=0.9.0.dev20160916100340
 munkres3==1.*
 pylint==1.*
 language-check==0.8.*

--- a/tests/js/JSComplexityBearTest.py
+++ b/tests/js/JSComplexityBearTest.py
@@ -59,18 +59,3 @@ JSComplexityBearInvalidFileTest = verify_local_bear(
     valid_files=(complexity_4, complexity_12),
     invalid_files=(),
     tempfile_kwargs={"suffix": ".not_js"})
-
-
-def get_available_decodeerror_test(monkeypatch):
-    class TestError(Exception):
-        pass
-    monkeypatch.setattr(
-        json.decoder, 'JSONDecodeError', TestError, raising=False)
-    result = JSComplexityBear.get_available_decodeerror()
-    assert result == TestError
-
-
-def get_available_decodeerror_py34_test(monkeypatch):
-    monkeypatch.delattr('json.decoder.JSONDecodeError', raising=False)
-    result = JSComplexityBear.get_available_decodeerror()
-    assert result == ValueError

--- a/tests/js/JSONFormatBearTest.py
+++ b/tests/js/JSONFormatBearTest.py
@@ -54,18 +54,3 @@ JSONFormatBearUnicodeTest = verify_local_bear(JSONFormatBear.JSONFormatBear,
                                               invalid_files=(),
                                               settings={'escape_unicode':
                                                         'false'})
-
-
-def get_available_decodeerror_test(monkeypatch):
-    class TestError(Exception):
-        pass
-    monkeypatch.setattr(
-        json.decoder, 'JSONDecodeError', TestError, raising=False)
-    result = JSONFormatBear.get_available_decodeerror()
-    assert result == TestError
-
-
-def get_available_decodeerror_py34_test(monkeypatch):
-    monkeypatch.delattr('json.decoder.JSONDecodeError', raising=False)
-    result = JSONFormatBear.get_available_decodeerror()
-    assert result == ValueError


### PR DESCRIPTION
JSComplexityBear.py and JSONFormatBear.py had a common function
get_available_decodeerror, which can lead to differences in future,
hence, it is unified in the compat module, from where the error is
imported.

Fixes https://github.com/coala-analyzer/coala/issues/2743