### PR TITLE
.ci: Add shellcheck tests for MacOSX

### DIFF
--- a/.ci/deps.osx.sh
+++ b/.ci/deps.osx.sh
@@ -1,0 +1,22 @@
+VERSION=0.4.4
+BIN_PATH=/usr/local/Cellar/shellcheck/
+
+install_shellcheck() {
+  brew update && brew install shellcheck
+}
+
+currently_installed_shellcheck_version() {
+  ls /usr/local/Cellar/shellcheck/
+}
+
+if [ ! -d $BIN_PATH ]; then
+  install_shellcheck
+else
+  EXISTING_VERSION=$(currently_installed_shellcheck_version)
+  if [ "$VERSION" != "$EXISTING_VERSION" ]; then
+    brew uninstall shellcheck
+    install_shellcheck
+  else
+    echo "Using cached ShellCheck $EXISTING_VERSION"
+  fi
+fi


### PR DESCRIPTION
The .ci folder did not include shellcheck test for MacOSX users.
Script checks shellcheck's existence in brew's directory and installs
shellcheck via Homebrew if it is outdated or not installed. Script is
deps.shellcheck.sh's version for MacOSX.

Fixes https://github.com/coala/coala-bears/issues/153