### PR TITLE
Upgrade libgmp10 to version 6

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -14,7 +14,7 @@ sudo add-apt-repository -y ppa:staticfloat/juliareleases
 sudo add-apt-repository -y ppa:staticfloat/julia-deps
 sudo add-apt-repository -y ppa:avsm/ppa
 sudo apt-get -y update
-deps="espeak libclang1-3.4 indent mono-mcs chktex hlint r-base julia luarocks verilator cppcheck flawfinder"
+deps="espeak libclang1-3.4 indent mono-mcs chktex hlint r-base julia libgmp10 luarocks verilator cppcheck flawfinder"
 deps_python_dbus="libdbus-glib-1-dev libdbus-1-dev"
 deps_python_gi="glib2.0-dev gobject-introspection libgirepository1.0-dev python3-cairo-dev"
 deps_perl="perl libperl-critic-perl"


### PR DESCRIPTION
When initialising Julia, without a ~/.julia , the following
warning is shown.

```
WARNING: Error during initialization of module GMP:
ErrorException("The dynamically loaded GMP library
(version 5.1.3 with __gmp_bits_per_limb == 64)
does not correspond to the compile time version
(version 6.1.0 with __gmp_bits_per_limb == 64).
Please rebuild Julia.")
```