### PR TITLE
Add tslint peer dependency typescript >=1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "postcss-cli": "~2",
     "remark-cli": "~2",
     "tslint": "~3",
+    "typescript": ">=1.7.3",
     "ramllint": "~1.2.2",
     "write-good": "~0.9.1"
   }


### PR DESCRIPTION
tslint does not install without typescript >=1.7.3
also being declared as a dependency.

Fixes https://github.com/coala/coala-bears/issues/866