### PR TITLE
FormatRBear.py: Allow disabling of braces on next line

### DIFF
--- a/bears/r/FormatRBear.py
+++ b/bears/r/FormatRBear.py
@@ -32,7 +32,7 @@ class FormatRBear:
     def create_arguments(filename, file, config_file,
                          r_keep_comments: bool=True,
                          r_keep_blank_lines: bool=True,
-                         r_braces_on_next_line: bool=False,
+                         r_braces_on_next_line: bool=None,
                          r_use_arrows: bool=False,
                          indent_size:
                          int=SpacingHelper.DEFAULT_TAB_WIDTH,
@@ -78,10 +78,13 @@ class FormatRBear:
         """
         options = {'source="' + escape(filename, '"\\') + '"',
                    'blank=' + _map_to_r_bool(r_keep_blank_lines),
-                   'brace.newline=' + _map_to_r_bool(r_braces_on_next_line),
                    'comment=' + _map_to_r_bool(r_keep_comments),
                    'arrow=' + _map_to_r_bool(r_use_arrows),
                    'indent=' + str(indent_size)}
+        if r_braces_on_next_line is not None:
+            options.add('brace.newline=' +
+                        _map_to_r_bool(r_braces_on_next_line))
+
         if r_max_expression_length:
             options.add('width.cutoff=' + str(r_max_expression_length))
 


### PR DESCRIPTION
Map r_use_braces_on_next_line to None if the user does not specify 
explicitly true/false while running the bear.

Closes https://github.com/coala/coala-bears/issues/514
