### PR TITLE
coafile: Improve commit message checking

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -29,6 +29,8 @@ bears = SpaceConsistencyBear
 
 [commit]
 bears = GitCommitBear
+shortlog_trailing_period = False
+shortlog_regex = ([^:]*|\S+: [A-Z0-9*].*)
 
 [LineCounting]
 enabled = False


### PR DESCRIPTION
This will catch things like:

- A (wrong) space before a colon
- Missing space after the colon
- Trailing period after shortlog
- Lower case char after the colon

all automatically!