### PR TITLE
LocalBearTestHelper.py: Adds doc_string for execute_bear

### DIFF
--- a/tests/LocalBearTestHelper.py
+++ b/tests/LocalBearTestHelper.py
@@ -14,6 +14,14 @@ from coalib.settings.Setting import Setting
 
 @contextmanager
 def execute_bear(bear, *args, **kwargs):
+    """
+    Execute the bear routine.
+
+    :param bear:    The bear instance to run.
+    :param args:    Arguments for the bear class
+    :param kwargs:  Keywords for the bear class
+    """
+
     try:
         bear_output_generator = bear.execute(*args, **kwargs)
         assert bear_output_generator is not None, \


### PR DESCRIPTION
Adds missing doc_string for execute_bear

Closes https://github.com/coala/coala-bears/issues/321

Includes improvements based on feedback from https://github.com/coala/coala-bears/pull/547 