### PR TITLE
InvalidLinkBear: Parse URLs wrapped with backticks

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -43,8 +43,8 @@ class InvalidLinkBear(LocalBear):
     def find_links_in_file(file, timeout, link_ignore_regex):
         link_ignore_regex = re.compile(link_ignore_regex)
         regex = re.compile(
-            r'((ftp|http)s?://[^.:\s_/?#[\]@\\]+\.(?:[^\s()\'"<>|\\]+|'
-            r'\([^\s()\'"<>|\\]*\))*)(?<!\.)(?<!,)')
+            r'((ftp|http)s?://[^.:\s_/?#[\]@\\]+\.(?:[^\s()\'"`<>|\\]+|'
+            r'\([^\s()\'"`<>|\\]*\))*)(?<!\.)(?<!,)')
         for line_number, line in enumerate(file):
             match = regex.search(line)
             if match:

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -83,6 +83,7 @@ class InvalidLinkBearTest(unittest.TestCase):
         "https://github.com/coala/coala-bears/issues/200"
         'http://httpbin.org/status/203'
         ('http://httpbin.org/status/200').install_command()
+        `https://coala.io/200`
 
         # Markup/down stuff
         <http://httpbin.org/status/202>

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -51,6 +51,14 @@ def custom_matcher(request):
 
 class InvalidLinkBearTest(unittest.TestCase):
 
+    """
+    The tests are mocked (don't actually connect to internet) and
+    return the int conversion of the last three chars of
+    the URL as status code.
+
+    Check ``custom matcher`` for more info on implementation.
+    """
+
     def setUp(self):
         self.section = Section("")
 


### PR DESCRIPTION
URLs wrapped within backticks are parsed correctly now,
\`https://coala.io/` -> https://coala.io

Added ` in the non-capturing group of regex
Also, added test for the same

Fixes https://github.com/coala/coala-bears/issues/860