### PR TITLE
SpellCheckBear.py: Update URL for scspell

### DIFF
--- a/bears/natural_language/SpellCheckBear.py
+++ b/bears/natural_language/SpellCheckBear.py
@@ -10,7 +10,7 @@ class SpellCheckBear:
     """
     Lints files to check for incorrect spellings using ``scspell``.
 
-    See <https://pypi.python.org/pypi/scspell> for more information.
+    See <https://pypi.python.org/pypi/scspell3k> for more information.
     """
     LANGUAGES = {"Natural Language"}
     REQUIREMENTS = {PipRequirement('scspell3k', '2.0')}


### PR DESCRIPTION
Updates URL from https://pypi.python.org/pypi/scspell 
to https://pypi.python.org/pypi/scspell3k.

Fixes https://github.com/coala/coala-bears/issues/908