### PR TITLE
InvalidLinkBear.py: Amend regex

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -43,8 +43,8 @@ class InvalidLinkBear(LocalBear):
     def find_links_in_file(file, timeout, link_ignore_regex):
         link_ignore_regex = re.compile(link_ignore_regex)
         regex = re.compile(
-            r'((ftp|http)s?://[^.:\s_/?#[\]@\\]+\.(?:[^\s()\'"`<>|\\]+|'
-            r'\([^\s()\'"`<>|\\]*\))*)(?<!\.)(?<!,)')
+            r'((ftp|http)s?://[^.:%\s_/?#[\]@\\]+\.(?:[^\s()%\'"`<>|\\]+|'
+            r'\([^\s()%\'"`<>|\\]*\))*)(?<!\.)(?<!,)')
         for line_number, line in enumerate(file):
             match = regex.search(line)
             if match:

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -107,6 +107,9 @@ class InvalidLinkBearTest(unittest.TestCase):
 
         # Not a link
         http://not a link dot com
+        http://www.%s.com
+        http://www.%d.com
+        http://www.%f.com
 
         # Redirect
         http://httpbin.org/status/301
@@ -119,7 +122,8 @@ class InvalidLinkBearTest(unittest.TestCase):
         http://httpbin.org/status/404
         http://httpbin.org/status/410
         http://httpbin.org/status/500
-        http://httpbin.org/status/503"""
+        http://httpbin.org/status/503
+        http://www.google.com/hello%20world"""
 
         for line in invalid_file.splitlines():
             self.assertResult(invalid_file=[line])


### PR DESCRIPTION
Modify regex to ignore placeholders like
``%s``,``%d``,``%f``, etc. and add corresponding
tests to InvalidLinkBearTest.py

Closes https://github.com/coala/coala-bears/issues/758