### PR TITLE
RELEASE_NOTES.rst: Fixed Spaceing

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -174,9 +174,10 @@ In this release, coala-bears has been revamped with new bears and more configs
 are added for existing bears.
 
 New bears:
+
 -  ``AutoPrefixBear`` (Add vendor prefixes automatically in CSS)
 -  ``ClangComplexityBear`` (Calculates cyclomatic complexity of each function
-    for C, C++ and other Clang supported languages.)
+   for C, C++ and other Clang supported languages.)
 -  ``GoTypeBear`` (Static analysis for Go code)
 -  ``PMDBear`` (Static analysis for Java code)
 -  ``CPDBear`` (Checks for code duplication in a file/multiple files)


### PR DESCRIPTION
Added a new line to make sure the bulleting starts with the correct item
previously AutoPrefixBear was on the same line as NewBears and was not getting a bullet, 
now it will look more uniform
Removed extra space to align for with backlash

Fixes https://github.com/coala/coala-bears/issues/919