### PR TITLE
InvalidLinkBear.py: Amend regex, ignore ``%s``,etc 

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -68,12 +68,48 @@ class InvalidLinkBear(LocalBear):
                                         # set of parenthesis.
                                         # An example can be:
                                         # http://wik.org/Hello_(Adele_song)/200
-            )
-            *)
-                                        # Thus, the whole part above
+            )                           # Thus, the whole part above
                                         # prevents matching of
                                         # Unbalanced parenthesis
+            (
+                (%?[0-9]+)              # A ``%`` sign (0 or 1 times)
+                                        # followed by any number
+                                        # Restricts URLs to end with
+                                        # a number (HTTP Status Code)
+                [^\s()%\'"`<>|\\]+      # Same regex for path name
+            |                           # OR
+                \([^\s()%\'"`<>|\\]*\)  # Same regex for path name
+                                        # contained within ()
+                ([^\s()%\'"`<>|\\]*)    # Same regex for path name
+                                        # for including HTTP Status Codes
+            )
             (?<!\.)(?<!,)               # Exclude trailing `.` or `,` from URL
+            )                           # First part of the regex ends here
+                                        # Covers URLs with or without
+                                        # placeholders but with necessary
+                                        # HTTP Status Codes at the end
+            |                           # OR (Second part of regex begins here)
+                                        # Covers URLs without any
+                                        # numbers at the end
+                                        # Essential for URLs with placeholders
+                                        # but without HTTP Status Codes
+            (((https?://                # http:// or https:// as only these
+                                        # are supported by the ``requests``
+                                        # library
+            [^.:%\s_/?#[\]@\\]+         # Initial part of domain
+            \.                          # A required dot `.`
+            (
+                (?:[^\s()%\'"`<>|\\]+)  # Same regex for path name
+            |                           # OR
+                \([^\s()%\'"`<>|\\]*\)  # Same regex for path name
+                                        # contained within ()
+            )
+            ))                          # Thus, the whole part above
+                                        # prevents matching of
+                                        # Unbalanced parenthesis
+            (?!(.))                     # Negative lookahead to match URLs not
+                                        # followed by any character
+            (?<!\.)(?<!,))              # Exclude trailing `.` or `,` from URL
             """, re.VERBOSE)
         for line_number, line in enumerate(file):
             match = regex.search(line)

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -81,6 +81,8 @@ class InvalidLinkBearTest(unittest.TestCase):
         http://httpbin.org/status/200
         http://httpbin.org/status/201
         http://httpbin.org/status/401  # Unauthorized
+        http://httpbin.org/status%20is/200
+        https://encrypted.google.com/search?hl=en&q=cpp+%25s+error/200
 
         # Parentheses
         https://en.wikipedia.org/wiki/Hello_(Adele_song)/200
@@ -108,6 +110,9 @@ class InvalidLinkBearTest(unittest.TestCase):
         http://www.%s.com
         http://www.%d.com
         http://www.%f.com
+        http://httpbin.org/%s/status/520
+        https://encrypted.google.com/search?hl=en&q=cpp+%s+error
+        http://www.%20.com
 
         # Redirect
         http://httpbin.org/status/301


### PR DESCRIPTION
Modify regex to include links with `%`
in between and to ignore placeholders
like `%s`,`%c`,`%f`, etc. and add corresponding
tests to InvalidLinkBearTest.py

Closes https://github.com/coala/coala-bears/issues/758
