### PR TITLE
bears/rest: Add rstcheckerBear

### DIFF
--- a/bears/rest/RSTcheckBear.py
+++ b/bears/rest/RSTcheckBear.py
@@ -1,0 +1,47 @@
+from coalib.bearlib.abstractions.Linter import linter
+from coalib.bears.requirements.PipRequirement import PipRequirement
+from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
+
+
+@linter(executable="rstcheck",
+        use_stdout=False,
+        use_stderr=True,
+        output_format="regex",
+        output_regex=r'.+\s?:(?P<line>\d+):\s'
+                     r'(?P<message>\((?P<severity>\w+).+)',
+        severity_map={"INFO": RESULT_SEVERITY.INFO,
+                      "WARNING": RESULT_SEVERITY.NORMAL,
+                      "ERROR": RESULT_SEVERITY.MAJOR,
+                      "SEVERE": RESULT_SEVERITY.MAJOR})
+class RSTcheckBear:
+
+    """
+    Check syntax of ``reStructuredText`` and code blocks
+    nested within it.
+
+    Check <https://pypi.python.org/pypi/rstcheck> for more information.
+    """
+
+    LANGUAGES = {'reStructuredText'}
+    REQUIREMENTS = {PipRequirement('rstcheck', '2.*')}
+    AUTHORS = {'The coala developers'}
+    AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
+    LICENSE = 'AGPL-3.0'
+    CAN_DETECT = {'Formatting', 'Syntax'}
+    ASCIINEMA_URL = 'https://asciinema.org/a/8ntlaqubk2qkrn9mm0dh07rlk?speed=2'
+
+    @staticmethod
+    def create_arguments(filename, file, config_file,
+                         code_block_language_ignore: list=()):
+        """
+        :param code_block_language_ignore:
+            Comma seperated list for languages of which code blocks
+            should be ignored. Code block of following languages
+            can be detected: ``bash``, ``c``, ``cpp``, ``json``,
+            ``python``, ``rst``.
+        """
+        args = ()
+        if code_block_language_ignore:
+            args = ('--ignore-language=' +
+                    ",".join(code_block_language_ignore),)
+        return args + (filename,)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ nbformat>=4.*
 pyflakes==1.2.*  # Although we don't need this directly, solves a dep conflict
 scspell3k==2.*
 mypy-lang==0.4.*
+rstcheck~=2.2

--- a/tests/rest/RSTcheckBearTest.py
+++ b/tests/rest/RSTcheckBearTest.py
@@ -1,0 +1,19 @@
+from bears.rest.RSTcheckBear import RSTcheckBear
+from tests.LocalBearTestHelper import verify_local_bear
+
+rst_syntax_good = "====\ntest\n====\n"
+rst_syntax_bad = "====\ntest\n===\n"
+
+python_block_good = "====\nTest\n====\n.. code-block:: python\n\n    print()"
+python_block_bad = "====\nTest\n====\n.. code-block:: python\n\n    print(\n"
+
+RSTcheckBearTest_ignore_no_code_block = verify_local_bear(
+                RSTcheckBear,
+                (rst_syntax_good, python_block_good),
+                (rst_syntax_bad, python_block_bad),
+                )
+RSTcheckBearTest_ignore_python_code_block = verify_local_bear(
+                RSTcheckBear,
+                (rst_syntax_good, python_block_bad, python_block_good),
+                (rst_syntax_bad,),
+                settings={"code_block_language_ignore": "python"})


### PR DESCRIPTION
Adds a bear for https://pypi.python.org/pypi/rstcheck to check
reStructuredText.

Closes https://github.com/coala/coala-bears/issues/902
