### PR TITLE
GitCommitBear: Print match regex with the message

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -121,7 +121,8 @@ class GitCommitBear(GlobalBear):
             if not match:
                 yield Result(
                     self,
-                    "Shortlog of HEAD commit does not match given regex.")
+                    "Shortlog of HEAD commit does not match given regex:"
+                    " {regex}".format(regex=shortlog_regex))
 
         if shortlog_imperative_check:
             colon_pos = shortlog.find(':')

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -200,13 +200,14 @@ class GitCommitBearTest(unittest.TestCase):
         self.git_commit("tag: message invalid.")
         self.assertEqual(
             self.run_uut(shortlog_regex=pattern),
-            ["Shortlog of HEAD commit does not match given regex."])
+            ["Shortlog of HEAD commit does not match given regex: {regex}"
+             .format(regex=pattern)])
 
         self.git_commit("SuCkS cOmPleTely")
         self.assertEqual(
             self.run_uut(shortlog_regex=pattern),
-            ["Shortlog of HEAD commit does not match given regex."])
-
+            ["Shortlog of HEAD commit does not match given regex: {regex}"
+             .format(regex=pattern)])
         # Check for full-matching.
         pattern = "abcdefg"
 
@@ -216,7 +217,8 @@ class GitCommitBearTest(unittest.TestCase):
         self.git_commit("abcdefgNO MATCH")
         self.assertEqual(
             self.run_uut(shortlog_regex=pattern),
-            ["Shortlog of HEAD commit does not match given regex."])
+            ["Shortlog of HEAD commit does not match given regex: {regex}"
+             .format(regex=pattern)])
 
     def test_body_checks(self):
         self.git_commit(


### PR DESCRIPTION
Fixes: https://github.com/coala/coala-bears/issues/942
