### PR TITLE
bears: Fix imports

### DIFF
--- a/bears/coffee_script/CoffeeLintBear.py
+++ b/bears/coffee_script/CoffeeLintBear.py
@@ -5,7 +5,7 @@ from coalib.bearlib.abstractions.Linter import linter
 from coalib.bears.requirements.NpmRequirement import NpmRequirement
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.results.Result import Result
-from coala_utils.param_convertion import negate
+from coala_utils.param_conversion import negate
 
 
 @linter(executable='coffeelint',

--- a/bears/java/JavaPMDBear.py
+++ b/bears/java/JavaPMDBear.py
@@ -2,7 +2,7 @@ from shutil import which
 
 from coalib.bearlib.abstractions.Linter import linter
 from coalib.bearlib import deprecate_settings
-from coala_utils.param_convertion import negate
+from coala_utils.param_conversion import negate
 
 
 @linter("bash", output_format="regex",

--- a/bears/js/JSHintBear.py
+++ b/bears/js/JSHintBear.py
@@ -3,7 +3,7 @@ import json
 from coalib.bearlib import deprecate_settings
 from coalib.bearlib.abstractions.Linter import linter
 from coalib.bears.requirements.NpmRequirement import NpmRequirement
-from coala_utils.param_convertion import negate
+from coala_utils.param_conversion import negate
 
 
 def bool_or_str(value):

--- a/bears/js/JSONFormatBear.py
+++ b/bears/js/JSONFormatBear.py
@@ -1,7 +1,7 @@
 import json
 from collections import OrderedDict
 
-from coala_utils.param_convertion import negate
+from coala_utils.param_conversion import negate
 from coalib.bearlib import deprecate_settings
 from coalib.bearlib.spacing.SpacingHelper import SpacingHelper
 from coalib.bears.LocalBear import LocalBear

--- a/bears/natural_language/WriteGoodLintBear.py
+++ b/bears/natural_language/WriteGoodLintBear.py
@@ -1,7 +1,7 @@
 from coalib.bearlib import deprecate_settings
 from coalib.bearlib.abstractions.Linter import linter
 from coalib.bears.requirements.NpmRequirement import NpmRequirement
-from coala_utils.param_convertion import negate
+from coala_utils.param_conversion import negate
 
 
 @linter(executable='write-good',

--- a/bears/ruby/RubySmellBear.py
+++ b/bears/ruby/RubySmellBear.py
@@ -5,7 +5,7 @@ from coalib.bearlib.abstractions.Linter import linter
 from coalib.bears.requirements.GemRequirement import GemRequirement
 from coalib.results.Result import Result
 from coalib.results.SourceRange import SourceRange
-from coala_utils.param_convertion import negate
+from coala_utils.param_conversion import negate
 
 
 @linter(executable='reek', use_stdin=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Use >= for development versions so that source builds always work
-coala>=0.9.0.dev20160916100340
+coala>=0.9.0.dev20161028145459
 munkres3==1.*
 pylint==1.*
 language-check==0.8.*


### PR DESCRIPTION
The module coala_utils.param_convertion.py was
renamed to coala_utils.param_conversion.py in
coala_utils 0.4.10. This caused some bears to throw
import errors.
This commit fixes the affected import lines.

Fixes https://github.com/coala/coala-bears/issues/945