### PR TITLE
InvalidLinkBear: Remove FTP from regex

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -43,7 +43,7 @@ class InvalidLinkBear(LocalBear):
     def find_links_in_file(file, timeout, link_ignore_regex):
         link_ignore_regex = re.compile(link_ignore_regex)
         regex = re.compile(
-            r'((ftp|http)s?://[^.:%\s_/?#[\]@\\]+\.(?:[^\s()%\'"`<>|\\]+|'
+            r'(https?://[^.:%\s_/?#[\]@\\]+\.(?:[^\s()%\'"`<>|\\]+|'
             r'\([^\s()%\'"`<>|\\]*\))*)(?<!\.)(?<!,)')
         for line_number, line in enumerate(file):
             match = regex.search(line)


### PR DESCRIPTION
Remove 'ftp' from regex variable in `find_links_in_file()`
method because Python `requests` library can't fetch the FTP
status code.

Closes https://github.com/coala/coala-bears/issues/906