### PR TITLE
DartLintBear: check settings validity

### DIFF
--- a/bears/dart/DartLintBear.py
+++ b/bears/dart/DartLintBear.py
@@ -19,5 +19,16 @@ class DartLintBear:
     CAN_DETECT = {'Syntax', 'Formatting'}
 
     @staticmethod
-    def create_arguments(filename, file, config_file):
+    def create_arguments(
+            filename, file, config_file,
+            use_spaces: bool=True, indent_size: int=2):
+
+        # use_spaces must be True and indent_size must be 2 because
+        # dartanalyzer only supports these settings
+        # see https://github.com/dart-lang/dart_style/issues/261
+        if (indent_size != 2 or not use_spaces):
+            raise ValueError(
+                "DartLintBear only supports `use_spaces=True` "
+                "and `indent_size=2`"
+            )
         return filename,

--- a/tests/dart/DartLintBearTest.py
+++ b/tests/dart/DartLintBearTest.py
@@ -1,5 +1,10 @@
+from queue import Queue
+
 from bears.dart.DartLintBear import DartLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
+from tests.LocalBearTestHelper import verify_local_bear, LocalBearTestHelper
+from tests.BearTestHelper import generate_skip_decorator
 
 
 good_file = """
@@ -30,3 +35,23 @@ DartLintBearTest = verify_local_bear(DartLintBear,
                                      valid_files=(good_file,),
                                      invalid_files=(bad_file,),
                                      tempfile_kwargs={"suffix": ".dart"})
+
+
+@generate_skip_decorator(DartLintBear)
+class DartLintBearConfigTest(LocalBearTestHelper):
+
+    def test_config_failure_use_spaces(self):
+        section = Section("name")
+        section.append(Setting('use_spaces', False))
+        bear = DartLintBear(section, Queue())
+
+        with self.assertRaises(AssertionError):
+            self.check_validity(bear, [], good_file)
+
+    def test_config_failure_wrong_indent_size(self):
+        section = Section("name")
+        section.append(Setting('indent_size', 3))
+        bear = DartLintBear(section, Queue())
+
+        with self.assertRaises(AssertionError):
+            self.check_validity(bear, [], good_file)


### PR DESCRIPTION
As pointed out here https://github.com/dart-lang/dart_style/issues/261
dartanalyzer only supports indentation using 2 spaces. This commit
changes DartLintBear to check that use_spaces is True and
indent_size is 2 and raises a ValueError if not.

Fixes https://github.com/coala/coala-bears/issues/897