### PR TITLE
README: Remove duplicated 'Authors' section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,15 +128,6 @@ For more information about how to do basic analysis, check out the
 
 -----
 
-=======
-Authors
-=======
-
-coala-bears is maintained by a growing community. Please take a look at the
-meta information in `setup.py <setup.py>`__ for current maintainers.
-
------
-
 ================
 Getting Involved
 ================


### PR DESCRIPTION
Remove 'Authors' section which is duplicated.

Closes https://github.com/coala/coala-bears/issues/918