### PR TITLE
YAMLLintBear: Disable `document-start` rule by default

### DIFF
--- a/bears/yml/YAMLLintBear.py
+++ b/bears/yml/YAMLLintBear.py
@@ -1,5 +1,6 @@
 from coalib.bearlib.abstractions.Linter import linter
 from coalib.bears.requirements.PipRequirement import PipRequirement
+import yaml
 
 
 @linter(executable='yamllint',
@@ -22,6 +23,27 @@ class YAMLLintBear:
     CAN_DETECT = {'Syntax', 'Formatting'}
 
     @staticmethod
+    def generate_config(filename, file,
+                        document_start: bool=False):
+        """
+        :param document_start:
+            Use this rule to require or forbid the use of document start
+            marker (---).
+        """
+        yamllint_configs = {
+            'extends': 'default',
+            'rules': {
+                'document-start': {
+                    'present': False
+                 }
+            }
+        }
+        if document_start:
+            yamllint_configs['rules']['document-start']['present'] = True
+
+        return yaml.dump(yamllint_configs)
+
+    @staticmethod
     def create_arguments(filename, file, config_file, yamllint_config: str=''):
         """
         :param yamllint_config: Path to a custom configuration file.
@@ -29,4 +51,6 @@ class YAMLLintBear:
         args = ('-f', 'parsable', filename)
         if yamllint_config:
             args += ('--config=' + yamllint_config,)
+        else:
+            args += ('--config-file=' + config_file,)
         return args

--- a/tests/yml/YAMLLintBearTest.py
+++ b/tests/yml/YAMLLintBearTest.py
@@ -18,6 +18,32 @@ items:
 ...
 """
 
+no_start_yml_file = """receipt: Oz-Ware Purchase Invoice
+date: 2012-08-06
+customer:
+    first_name: Dorothy
+    family_name: Gale
+
+items:
+    - part_no: A4786
+      descrip: Water Bucket (Filled)
+      price: 1.47
+      quantity: 4"""
+
+with_start_yml_file = """---
+receipt: Oz-Ware Purchase Invoice
+date: 2012-08-06
+customer:
+    first_name: Dorothy
+    family_name: Gale
+
+items:
+    - part_no: A4786
+      descrip: Water Bucket (Filled)
+      price: 1.47
+      quantity: 4
+..."""
+
 config_file = """
 extends:
     default
@@ -42,3 +68,13 @@ with prepare_file(config_file,
                                           invalid_files=(),
                                           settings={
                                               'yamllint_config': conf_file})
+
+YAMLLintBear3Test = verify_local_bear(YAMLLintBear,
+                                      valid_files=(no_start_yml_file,),
+                                      invalid_files=(with_start_yml_file,))
+
+YAMLLintBear4Test = verify_local_bear(YAMLLintBear,
+                                      valid_files=(with_start_yml_file,),
+                                      invalid_files=(no_start_yml_file,),
+                                      settings={
+                                          'document_start': True})


### PR DESCRIPTION
Disable YAMLLint rule `document-start` by default because
many YAML files have no need for start and end markers, but
user still can enable it by using `document_start=true`
setting.

Add unit tests for YAMLLintBear.

Closes https://github.com/coala/coala-bears/issues/923