### PR TITLE
GitCommitBear.py: Rename param in docstring

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -148,7 +148,7 @@ class GitCommitBear(GlobalBear):
 
         :param paragraph:
             The input paragraph to be tested.
-        :returns:
+        :return:
             A list of tuples having 2 elements (invalid word, parts of speech)
             or an empty list if no invalid words are found.
         """


### PR DESCRIPTION
Change docstring to use 'return' instead of 'returns'.
Fixes #571