### PR TITLE
Replace pull request https://github.com/coala/coala-bears/pull/951, which had a history beyond saving, because it was done during the pycon sprint.

### DIFF
--- a/bears/c_languages/CPPLintBear.py
+++ b/bears/c_languages/CPPLintBear.py
@@ -25,6 +25,8 @@ class CPPLintBear:
     @staticmethod
     def create_arguments(filename, file, config_file,
                          max_line_length: int=79,
+                         use_spaces: bool=True,
+                         indent_size: int=2,
                          cpplint_ignore: typed_list(str)=(),
                          cpplint_include: typed_list(str)=()):
         """
@@ -32,6 +34,10 @@ class CPPLintBear:
         :param cpplint_ignore:  List of checkers to ignore.
         :param cpplint_include: List of checkers to explicitly enable.
         """
+        if (not use_spaces):
+            raise ValueError("CPPLint requires use_spaces=True")
+        if (indent_size != 2):
+            raise ValueError("CPPLint requires indent_size=2")
         ignore = ','.join('-'+part.strip() for part in cpplint_ignore)
         include = ','.join('+'+part.strip() for part in cpplint_include)
         return ('--filter=' + ignore + ',' + include,

--- a/tests/c_languages/CPPLintBearTest.py
+++ b/tests/c_languages/CPPLintBearTest.py
@@ -1,5 +1,9 @@
 from bears.c_languages.CPPLintBear import CPPLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from tests.LocalBearTestHelper import LocalBearTestHelper, verify_local_bear
+from queue import Queue
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
+from tests.BearTestHelper import generate_skip_decorator
 
 test_file = """
 int main() {
@@ -13,16 +17,42 @@ CPPLintBearTest = verify_local_bear(CPPLintBear,
                                     tempfile_kwargs={"suffix": ".cpp"})
 
 CPPLintBearIgnoreConfigTest = verify_local_bear(
-    CPPLintBear,
-    valid_files=(test_file,),
-    invalid_files=(),
-    settings={'cpplint_ignore': 'legal'},
-    tempfile_kwargs={"suffix": ".cpp"})
+        CPPLintBear,
+        valid_files=(test_file,),
+        invalid_files=(),
+        settings={'cpplint_ignore': 'legal'},
+        tempfile_kwargs={"suffix": ".cpp"})
 
 CPPLintBearLineLengthConfigTest = verify_local_bear(
-    CPPLintBear,
-    valid_files=(),
-    invalid_files=(test_file,),
-    settings={'cpplint_ignore': 'legal',
-              'max_line_length': '13'},
-    tempfile_kwargs={"suffix": ".cpp"})
+        CPPLintBear,
+        valid_files=(),
+        invalid_files=(test_file,),
+        settings={'cpplint_ignore': 'legal',
+                  'max_line_length': '13'},
+        tempfile_kwargs={"suffix": ".cpp"})
+
+
+@generate_skip_decorator(CPPLintBear)
+class CPPLintBearTest(LocalBearTestHelper):
+
+    def setUp(self):
+        self.section = Section("test section")
+        # uut = unit under test
+        self.uut = CPPLintBear(self.section, Queue())
+
+    def test_config_failure_use_spaces(self):
+        self.section["use_spaces"] = "False"
+        self.section.append(Setting('use_spaces', "False"))
+        with self.assertRaises(AssertionError):
+            self.check_validity(self.uut, [], test_file)
+
+    def test_config_success_indent_size(self):
+        self.section["indent_size"] = "2"
+        self.section.append(Setting('indent_size', "2"))
+        self.check_validity(self.uut, [], test_file)
+
+    def test_config_failure_indent_size(self):
+        self.section["indent_size"] = "4"
+        self.section.append(Setting('indent_size', "4"))
+        with self.assertRaises(AssertionError):
+            self.check_validity(self.uut, [], test_file)


### PR DESCRIPTION
Similar to java's LanguageCheck, CPPLint only supports certain kinds of
settings (use_spaces can only be true, indent_size has to be 2).

Consistent with what LanguageCheck does, this commit makes
CPPLintBear throw ValueError in case unsupported options are passed.

Extends test-case to test for exceptions being thrown for unsupported
options.