### PR TITLE
YAMLLintBear.py: Correct argument "--config" to "--config-file"

### DIFF
--- a/bears/yml/YAMLLintBear.py
+++ b/bears/yml/YAMLLintBear.py
@@ -50,7 +50,7 @@ class YAMLLintBear:
         """
         args = ('-f', 'parsable', filename)
         if yamllint_config:
-            args += ('--config=' + yamllint_config,)
+            args += ('--config-file=' + yamllint_config,)
         else:
             args += ('--config-file=' + config_file,)
         return args


### PR DESCRIPTION
Corrected the argument at line 53 to ``--config-file``

Fixes https://github.com/coala/coala-bears/issues/979