### PR TITLE
Do not require language_check for coala-bears

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -93,6 +93,7 @@ for dep_version in "${dep_versions[@]}" ; do
   pip install -U setuptools
   pip install -r test-requirements.txt
   pip install -r requirements.txt
+  pip install language_check==0.8.*
 done
 
 pip install -r docs-requirements.txt

--- a/bears/natural_language/LanguageToolBear.py
+++ b/bears/natural_language/LanguageToolBear.py
@@ -1,7 +1,6 @@
 import shutil
 
 from guess_language import guess_language
-from language_check import LanguageTool, correct
 
 from coalib.bearlib import deprecate_settings
 from coalib.bears.LocalBear import LocalBear
@@ -14,7 +13,8 @@ from coalib.settings.Setting import typed_list
 
 class LanguageToolBear(LocalBear):
     LANGUAGES = {"Natural Language"}
-    REQUIREMENTS = {PipRequirement('guess-language-spirit', '0.5.*')}
+    REQUIREMENTS = {PipRequirement('guess-language-spirit', '0.5.*'),
+                    PipRequirement('language-check', '0.8.*')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'
@@ -25,7 +25,11 @@ class LanguageToolBear(LocalBear):
         if shutil.which("java") is None:
             return "java is not installed."
         else:
-            return True
+            try:
+                from language_check import LanguageTool, correct
+                return True
+            except ImportError:  # pragma: no cover
+                return "Please install the `language-check` pip package."
 
     @deprecate_settings(language='locale')
     def run(self,
@@ -43,6 +47,10 @@ class LanguageToolBear(LocalBear):
                                            'en-US' is used.
         :param languagetool_disable_rules: List of rules to disable checks for.
         '''
+        # Defer import so the check_prerequisites can be run without
+        # language_check being there.
+        from language_check import LanguageTool, correct
+
         joined_text = "".join(file)
         language = (guess_language(joined_text)
                     if language == 'auto' else language)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 coala>=0.9.0.dev20161112225154
 munkres3==1.*
 pylint==1.*
-language-check==0.8.*
 autopep8==1.*
 eradicate==0.1.*
 autoflake==0.6.*


### PR DESCRIPTION
A lot of people are struggling because we actually require java to
install coala-bears. That sucks. Let's rather have this one bear not
work by default than all of those users giving up on the whole tool.

We can even have a nice message.