### PR TITLE
New Bear: PycodestyleBear

### DIFF
--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -1,0 +1,50 @@
+from coalib.bearlib.abstractions.Linter import linter
+
+from coalib.bears.requirements.PipRequirement import PipRequirement
+
+
+@linter(executable='pycodestyle',
+        output_format='regex',
+        output_regex=r'(?P<line>\d+) (?P<column>\d+) '
+                     r'(?P<message>(?P<origin>\S+).*)')
+class PycodestyleBear:
+    """
+    A wrapper for the tool ``pycodestyle`` formerly known as ``pep8``.
+    """
+    LANGUAGES = {"Python", "Python 2", "Python 3"}
+    REQUIREMENTS = {PipRequirement('pycodestyle')}
+    AUTHORS = {'The coala developers'}
+    AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
+    LICENSE = 'AGPL-3.0'
+    CAN_DETECT = {'Formatting'}
+
+    @staticmethod
+    def create_arguments(
+            filename, file, config_file,
+            pycodestyle_ignore: str="",
+            pycodestyle_select: str="",
+            max_line_length: int=79):
+        """
+        :param pycodestyle_ignore:
+            Comma separated list of errors to ignore.
+            See ``pydocstyle`` documentation for a complete list of errors.
+        :param pycodestyle_select:
+            Comma separated list of errors to detect. If given only
+            these errors are going to be detected.
+            See ``pydocstyle`` documentation for a complete list of errors.
+        :param max_line_length:
+            Limit lines to this length.
+        """
+        arguments = [r"--format='%(row)d %(col)d %(code)s %(text)s'"]
+
+        if pycodestyle_ignore:
+            arguments.append("--ignore=" + pycodestyle_ignore)
+
+        if pycodestyle_select:
+            arguments.append("--select=" + pycodestyle_select)
+
+        arguments.append("--max-line-length=" + str(max_line_length))
+
+        arguments.append(filename)
+
+        return arguments

--- a/tests/python/PycodestyleBearTest.py
+++ b/tests/python/PycodestyleBearTest.py
@@ -1,0 +1,50 @@
+from bears.python.PycodestyleBear import PycodestyleBear
+from tests.LocalBearTestHelper import verify_local_bear
+
+
+good_file = '''
+def hello():
+    print("hello world")
+'''
+
+
+bad_file = '''
+import something
+
+
+
+def hello():
+    print("hello world")
+'''
+
+PycodestyleBearTest = verify_local_bear(
+    PycodestyleBear,
+    valid_files=(good_file,),
+    invalid_files=(bad_file,))
+
+PycodestyleBearConfigIgnoreTest = verify_local_bear(
+    PycodestyleBear,
+    valid_files=(good_file, bad_file),
+    invalid_files=[],
+    settings={"pycodestyle_ignore": "E303"})
+
+PycodestyleBearConfigSelectTest = verify_local_bear(
+    PycodestyleBear,
+    valid_files=(good_file, bad_file),
+    invalid_files=[],
+    settings={"pycodestyle_select": "E300"})
+
+long_line = 'a = "{0}"'.format("a" * 100)
+
+PycodestyleBearLineLengthTest = verify_local_bear(
+    PycodestyleBear,
+    valid_files=(),
+    invalid_files=(long_line,)
+)
+
+PycodestyleBearLineLengthTest = verify_local_bear(
+    PycodestyleBear,
+    valid_files=(long_line,),
+    invalid_files=(),
+    settings={"max_line_length": 200}
+)


### PR DESCRIPTION
A wrapper for `pycodestyle` formerly known
as `pep8`.

Closes https://github.com/coala/coala-bears/issues/986