### PR TITLE
AnnotationBear: Search after annotation length

### DIFF
--- a/bears/general/AnnotationBear.py
+++ b/bears/general/AnnotationBear.py
@@ -203,7 +203,9 @@ class AnnotationBear(LocalBear):
             A SourceRange object holding the range of the multi-line annotation
             and the end_position of the annotation as an integer.
         """
-        end_end = get_end_position(annotation_end, text, position)
+        end_end = get_end_position(annotation_end,
+                                   text,
+                                   position + len(annotation_start) - 1)
         if end_end == -1:
             _range = SourceRange.from_absolute_position(
                 filename,
@@ -240,7 +242,9 @@ class AnnotationBear(LocalBear):
             A SourceRange object identifying the range of the single-line
             string and the end_position of the string as an integer.
         """
-        end_position = get_end_position(string_end, text, position)
+        end_position = get_end_position(string_end,
+                                        text,
+                                        position + len(string_start) - 1)
         newline = get_end_position("\n", text, position)
         if newline == -1:
             newline = len(text)
@@ -274,7 +278,9 @@ class AnnotationBear(LocalBear):
             A SourceRange object identifying the range of the single-line
             comment and the end_position of the comment as an integer.
         """
-        end_position = get_end_position("\n", text, position)
+        end_position = get_end_position("\n",
+                                        text,
+                                        position + len(comment) - 1)
         if end_position == -1:
             end_position = len(text) - 1
         return (SourceRange.from_absolute_position(

--- a/tests/general/AnnotationBearTest.py
+++ b/tests/general/AnnotationBearTest.py
@@ -150,3 +150,15 @@ class AnnotationBearTest(unittest.TestCase):
             AbsolutePosition(text, text[0].find("'", 4)))
         with execute_bear(uut, "F", text) as result:
             self.assertEqual(result[0].contents["strings"], (test_range,))
+
+        text = ['''
+            """"quoting inside quoting"
+            """
+            ''']
+        uut = AnnotationBear(self.section1, Queue())
+        with execute_bear(uut, "F", text) as results:
+            for result in results:
+                # The """" was recognized as a string start and end before.
+                # That lead to a Result being yielded because of unclosed
+                # quotes, this asserts that no such thing happened.
+                self.assertEqual(type(result), HiddenResult)


### PR DESCRIPTION
Right now AnnotationBear searches 1 position after annotation
which caused problems in
tests/c_languages/codeclone_detection/ClangASTPrintBearTest.py
and
tests/general/QuotesBearTest.py

Fixes https://github.com/coala/coala-bears/issues/1006