### PR TITLE
Remove explicit pyflakes requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ pyyaml==3.*
 vulture==0.10.*
 bandit==1.1.*
 nbformat>=4.*
-pyflakes==1.2.*  # Although we don't need this directly, solves a dep conflict
 scspell3k==2.*
 mypy-lang==0.4.*
 rstcheck~=2.2


### PR DESCRIPTION
pyflakes is not used directly by the bears.
It is indirectly used by autoflake, which
requires pyflakes>=0.8.1

Reverts e92774f0