### PR TITLE
RELEASE_NOTES.rst: Fix newline error

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -110,6 +110,7 @@ You can look up the new settings at https://coala.io/languages.
   (https://github.com/coala/coala-bears/issues/998)
 - The dependencies of the following bears were bumped due to upstream
   bugfixes:
+
     - `AlexBear`
     - `CPPCleanBear`
     - `ESLintBear`


### PR DESCRIPTION
This file was missing a newline at line 113, which caused a unexpected indentation error in the sublist.

Fixes https://github.com/coala/coala-bears/issues/1052