### PR TITLE
generate_packageTest.py: Fix NoBearPath to conform with glob

### DIFF
--- a/tests/generate_packageTest.py
+++ b/tests/generate_packageTest.py
@@ -87,7 +87,7 @@ class MainTest(unittest.TestCase):
 
     CSS_BEAR_SETUP_PATH = os.path.join(
         'bears', 'upload', 'CSSLintBear', 'setup.py')
-    NO_BEAR_PATH = os.path.join('bears', 'BadBear', 'NoBearHere.py')
+    NO_BEAR_PATH = os.path.join('bears', 'BadBear', 'InvalidBear.py')
 
     def setUp(self):
         self.argv = ['generate_package.py']


### PR DESCRIPTION
Made the bad bear(empty file) in the test conform
to the glob that generate_package.py matches to
locate bears to allow it to test the empty bear branch.

Fixes https://github.com/coala/coala-bears/issues/1055