### PR TITLE
0.9_test_fix backport to 0.9

### DIFF
--- a/tests/generate_packageTest.py
+++ b/tests/generate_packageTest.py
@@ -87,7 +87,7 @@ class MainTest(unittest.TestCase):
 
     CSS_BEAR_SETUP_PATH = os.path.join(
         'bears', 'upload', 'CSSLintBear', 'setup.py')
-    NO_BEAR_PATH = os.path.join('bears', 'BadBear', 'NoBearHere.py')
+    NO_BEAR_PATH = os.path.join('bears', 'BadBear', 'InvalidBear.py')
 
     def setUp(self):
         self.argv = ['generate_package.py']


### PR DESCRIPTION
**Backport**
Made the NoBearPath(empty file) in the test conform
to the glob that generate_package.py matches to
locate bears to allow it to test the empty bear branch.

Fixes https://github.com/coala/coala-bears/issues/1055