### PR TITLE
YapfBear.py : Delete check_prerequisites method

### DIFF
--- a/bears/python/YapfBear.py
+++ b/bears/python/YapfBear.py
@@ -174,10 +174,3 @@ space_between_ending_comma_and_closing_bracket= \
                          'provided.',
                          affected_code=(diff.range(filename),),
                          diffs={filename: diff})
-
-    @classmethod
-    def check_prerequisites(cls):  # pragma: no cover
-        if not sys.version_info >= (3, 4):
-            return 'Yapf only supports Python 2.7 and Python 3.4+'
-        else:
-            return True


### PR DESCRIPTION
This removes check_prerequisites that was not needed as bears already checks for python ver 3.4+

Closes https://github.com/coala/coala-bears/issues/928