### PR TITLE
coala-bears/tests/general/AnnotationBearTest.py: Deleted an extra space

### DIFF
--- a/tests/general/AnnotationBearTest.py
+++ b/tests/general/AnnotationBearTest.py
@@ -6,7 +6,7 @@ from bears.general.AnnotationBear import AnnotationBear
 from coala_utils.string_processing.Core import escape
 from coalib.results.SourceRange import SourceRange
 from coalib.results.AbsolutePosition import AbsolutePosition
-from coalib. results.HiddenResult import HiddenResult
+from coalib.results.HiddenResult import HiddenResult
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 from tests.LocalBearTestHelper import execute_bear


### PR DESCRIPTION
Deleted an unnecessary space in the import statement that imports HiddenResult

Fixes https://github.com/coala/coala/issues/3153