### PR TITLE
CheckstyleBear.py : modified create_argument() return

### DIFF
--- a/bears/c_languages/CPPLintBear.py
+++ b/bears/c_languages/CPPLintBear.py
@@ -3,6 +3,12 @@ from coalib.bears.requirements.PipRequirement import PipRequirement
 from coalib.settings.Setting import typed_list
 
 
+def check_invalid_configuration(use_spaces, indent_size):
+    if (not use_spaces or indent_size != 2):
+        return False
+    return True
+
+
 @linter(executable='cpplint',
         use_stdout=False,
         use_stderr=True,
@@ -26,14 +32,22 @@ class CPPLintBear:
     def create_arguments(filename, file, config_file,
                          max_line_length: int=79,
                          cpplint_ignore: typed_list(str)=(),
-                         cpplint_include: typed_list(str)=()):
+                         cpplint_include: typed_list(str)=(),
+                         use_spaces: bool=True,
+                         indent_size: int=2):
         """
         :param max_line_length: Maximum number of characters for a line.
         :param cpplint_ignore:  List of checkers to ignore.
         :param cpplint_include: List of checkers to explicitly enable.
+        :param use_spaces: Bool value whether to use spaces or not.
+        :param indent_size: Size of indentation when spaces are used.
         """
-        ignore = ','.join('-'+part.strip() for part in cpplint_ignore)
-        include = ','.join('+'+part.strip() for part in cpplint_include)
-        return ('--filter=' + ignore + ',' + include,
-                '--linelength=' + str(max_line_length),
-                filename)
+        if check_invalid_configuration(use_spaces, indent_size):
+            ignore = ','.join('-'+part.strip() for part in cpplint_ignore)
+            include = ','.join('+'+part.strip() for part in cpplint_include)
+            return ('--filter=' + ignore + ',' + include,
+                    '--linelength=' + str(max_line_length),
+                    filename)
+        else:
+            raise ValueError("CPPLint doesn't support indent_size!=2 or "
+                             'not using spaces.')

--- a/bears/go/GofmtBear.py
+++ b/bears/go/GofmtBear.py
@@ -20,6 +20,7 @@ class GofmtBear:
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'
     CAN_FIX = {'Formatting'}
+    ASCIINEMA_URL = 'https://asciinema.org/a/94812'
 
     @staticmethod
     def create_arguments(filename, file, config_file):

--- a/bears/java/CheckstyleBear.py
+++ b/bears/java/CheckstyleBear.py
@@ -8,7 +8,7 @@ _online_styles = {
     'geosoft': 'http://geosoft.no/development/geosoft_checks.xml'}
 
 # To be deprecated
-known_checkstyles = dict(_online_styles , **{'google': None, 'sun': None})
+known_checkstyles = dict(_online_styles, **{'google': None, 'sun': None})
 
 
 def check_invalid_configuration(checkstyle_configs, use_spaces, indent_size):

--- a/bears/java/CheckstyleBear.py
+++ b/bears/java/CheckstyleBear.py
@@ -8,7 +8,7 @@ _online_styles = {
     'geosoft': 'http://geosoft.no/development/geosoft_checks.xml'}
 
 # To be deprecated
-known_checkstyles = dict(_online_styles, **{'google': None, 'sun': None})
+known_checkstyles = dict(_online_styles , **{'google': None, 'sun': None})
 
 
 def check_invalid_configuration(checkstyle_configs, use_spaces, indent_size):
@@ -85,5 +85,5 @@ class CheckstyleBear:
                 _online_styles[checkstyle_configs],
                 checkstyle_configs + '.xml')
 
-        return ('-jar', self.checkstyle_jar_file, '-c',
+        return ('-jar', type(self).checkstyle_jar_file, '-c',
                 checkstyle_configs, filename)

--- a/tests/c_languages/CPPLintBearTest.py
+++ b/tests/c_languages/CPPLintBearTest.py
@@ -26,3 +26,19 @@ CPPLintBearLineLengthConfigTest = verify_local_bear(
     settings={'cpplint_ignore': 'legal',
               'max_line_length': '13'},
     tempfile_kwargs={'suffix': '.cpp'})
+
+CPPLintBearIndentSizeConfigTest = verify_local_bear(
+    CPPLintBear,
+    valid_files=(),
+    invalid_files=(test_file,),
+    settings={'cpplint_ignore': 'legal',
+              'use_spaces': 'False'},
+    tempfile_kwargs={'suffix': '.cpp'})
+
+CPPLintBearUseSpacesConfigTest = verify_local_bear(
+    CPPLintBear,
+    valid_files=(),
+    invalid_files=(test_file),
+    settings={'cpplint_ignore': 'legal',
+              'indent_size': '4'},
+    tempfile_kwargs={'suffix': '.cpp'},)


### PR DESCRIPTION
The commit demonstrates issue regarding the calling of
checkstyle_jar_file var as a static function , earlier
returned as static var.

Fixes https://github.com/coala/coala-bears/issues/1084