### PR TITLE
LocalBearTestHelper.py: Remove unused imports

### DIFF
--- a/tests/LocalBearTestHelper.py
+++ b/tests/LocalBearTestHelper.py
@@ -2,5 +2,3 @@ import logging
 
 logging.warning('This module is deprecated. Use '
                 '`coalib.testing.LocalBearTestHelper` instead.')
-
-from coalib.testing.LocalBearTestHelper import *


### PR DESCRIPTION
removed unused import
"from coala.coalib.testing.LocalBearTestHelper.py import *"

closes https://github.com/coala/coala-bears/issues/1057