### PR TITLE
Remove libclang-py3 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 # Use >= for development versions so that source builds always work
 coala>=0.9
+# Dependencies inherited from coala
+# libclang-py3
+# coala_utils
 munkres3~=1.0
 pylint~=1.6
 autopep8~=1.2
@@ -11,8 +14,6 @@ cpplint~=1.3
 yapf~=0.14.0
 isort~=4.2
 html-linter~=0.3.0
-# Do *not* use 0.3 which is not backwards compatible to common clang versions
-libclang-py3~=0.2.0
 guess-language-spirit~=0.5.2
 radon~=1.4
 requests~=2.12


### PR DESCRIPTION
This dependency is already managed by the coala package.
Due to continuous integration coala and coala-bears installing the
latest master of the other package, it can not be modified if it
appears in both otherwise a pkg_resources.ContextualVersionConflict
is raised when it is used.

Fixes https://github.com/coala/coala-bears/issues/1110