### PR TITLE
Ignore multiple urls

### DIFF
--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -203,3 +203,29 @@ class InvalidLinkBearTest(unittest.TestCase):
 
         for line in brokenlink_at_hash.splitlines():
             self.assertResult(invalid_file=[line])
+
+    def test_links_to_ignore(self):
+        valid_file = """http://httpbin.org/status/200
+        http://httpbin.org/status/201
+        http://coalaisthebest.com/
+        http://httpbin.org/status/404
+        http://httpbin.org/status/410
+        http://httpbin.org/status/500
+        http://httpbin.org/status/503
+        http://www.notexample.com/404
+        http://exampe.com/404
+        http://example.co.in/404""".splitlines()
+
+        link_ignore_list = [
+                           'http://coalaisthebest.com/',
+                           'http://httpbin.org/status/4[0-9][0-9]',
+                           'http://httpbin.org/status/410',
+                           'http://httpbin.org/status/5[0-9][0-9]',
+                           'http://httpbin.org/status/503',
+                           'http://www.notexample.com/404',
+                           'http://exampe.com/404',
+                           'http://example.co.in/404'
+                          ]
+
+        self.assertResult(valid_file=valid_file,
+                          settings={'link_ignore_list': link_ignore_list})


### PR DESCRIPTION
Ensures that multiple urls can be ignored according to
links_to_ignore setting (comma separated urls).

Closes https://github.com/coala/coala-bears/issues/1106