### PR TITLE
deps.sh: Do not install suggested packages for R

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -78,8 +78,8 @@ npm install
 # R commands
 echo '.libPaths( c( "'"$R_LIB_USER"'", .libPaths()) )' >> .Rprofile
 echo 'options(repos=structure(c(CRAN="http://cran.rstudio.com")))' >> .Rprofile
-R -e "install.packages('lintr', dependencies=TRUE, quiet=TRUE, verbose=FALSE)"
-R -e "install.packages('formatR', dependencies=TRUE, quiet=TRUE, verbose=FALSE)"
+R -q -e 'install.packages("lintr")'
+R -q -e 'install.packages("formatR")'
 
 # GO commands
 go get -u github.com/golang/lint/golint


### PR DESCRIPTION
Replace install.packages parameter `dependencies=True` with
only 'Depends'.
The default, `NA`, means `c("Depends", "Imports", "LinkingTo")`,
while `True` also includes `"Suggests"`.
Those options allow running examples, tests and vignettes, which
are not necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coala/coala-bears/1121)
<!-- Reviewable:end -->
