### PR TITLE
CircleCI: Do not install precise hlint

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,6 @@ dependencies:
     - ~/.local/share/coala-bears
     - ~/bakalint-0.4.0
     - ~/.julia
-    - ~/hlint_1.9.26-1_amd64.deb
   pre:
     - sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial
     - echo 'export PATH=$PATH:~/coala-bears/node_modules/.bin' >> ~/.circlerc


### PR DESCRIPTION
precise hlint is 1.8.24, which isnt usable as --json was added
in version 1.9.1.

The build script currently installs precise hlint, and then replaces
it with a seemingly custom .deb of 1.9.26.

The trusty hlint is 1.8.54, however xenial hlint is 1.9.26,
so it can be installed using apt-get on the trusty image.

Also move the .deb save location to ~/.apt-cache, with the
other cached .debs.