### PR TITLE
CircleCI: Move R cache to be same as Travis

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -66,8 +66,13 @@ sudo rm -rf /opt/alex # Delete ghc-alex as it clashes with npm deps
 npm install
 
 # R commands
-mkdir -p ~/.RLibrary
-echo '.libPaths( c( "~/.RLibrary", .libPaths()) )' >> .Rprofile
+if [[ ! -d ~/R/Library/ ]]; then
+  mkdir -p ~/R/Library/
+  if [[ -d ~/.RLibrary/ ]]; then
+    cp -rp ~/.RLibrary/* ~/R/Library
+  fi
+fi
+echo '.libPaths( c( "~/R/Library", .libPaths()) )' >> .Rprofile
 echo 'options(repos=structure(c(CRAN="http://cran.rstudio.com")))' >> .Rprofile
 R -e "install.packages('lintr', dependencies=TRUE, quiet=TRUE, verbose=FALSE)"
 R -e "install.packages('formatR', dependencies=TRUE, quiet=TRUE, verbose=FALSE)"

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ dependencies:
     - ~/coala-bears/.bundle
     - ~/coala-bears/vendor
     - ~/.RLibrary
+    - ~/R/Library
     - ~/dart-sdk/bin
     - ~/.cabal
     - ~/infer-linux64-v0.7.0


### PR DESCRIPTION
Travis CI has native R caching in ~/R/Library.
coala-bears has custom R caching in ~/.RLibrary.
Move the custom R caching to be consistent with Travis CI,
while maintaining the cache for existing branches.
