### PR TITLE
deps.sh: Cache installed tailor

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -148,8 +148,14 @@ if [ ! -e ~/pmd-bin-5.4.1/bin ]; then
 fi
 
 # Tailor (Swift) commands
-curl -fsSL https://tailor.sh/install.sh | sed 's/read -r CONTINUE < \/dev\/tty/CONTINUE=y/' > install.sh
-sudo bash install.sh
+# Comment out the hardcoded PREFIX, so we can put it into ~/.local
+if [ ! -e ~/.local/tailor/tailor-latest ]; then
+  curl -fsSL -o install.sh https://tailor.sh/install.sh
+  sed -i 's/read -r CONTINUE < \/dev\/tty/CONTINUE=y/;;s/^PREFIX.*/# PREFIX=""/;' install.sh
+  PREFIX=$HOME/.local bash ./install.sh
+  # Provide a constant path for the executable
+  ln -s ~/.local/tailor/tailor-* ~/.local/tailor/tailor-latest
+fi
 
 # making coala cache the dependencies downloaded upon first run
 echo '' > dummy

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ cache:
     - ~/pmd-bin-5.4.1
     - ~/bakalint-0.4.0
     - ~/dart-sdk/bin
+    - ~/.local/tailor/
 
 env:
   global:
@@ -60,7 +61,7 @@ env:
     - USE_PPAS=true
     - R_LIB_USER=~/R/Library
     - LINTR_COMMENT_BOT=false
-    - PATH="$PATH:$TRAVIS_BUILD_DIR/node_modules/.bin:$TRAVIS_BUILD_DIR/vendor/bin:$HOME/dart-sdk/bin:$HOME/.cabal/bin:$HOME/infer-linux64-v0.7.0/infer/bin:$HOME/pmd-bin-5.4.1/bin:/$HOME/bakalint-0.4.0"
+    - PATH="$PATH:$TRAVIS_BUILD_DIR/node_modules/.bin:$TRAVIS_BUILD_DIR/vendor/bin:$HOME/dart-sdk/bin:$HOME/.cabal/bin:$HOME/infer-linux64-v0.7.0/infer/bin:$HOME/pmd-bin-5.4.1/bin:$HOME/bakalint-0.4.0:$HOME/.local/tailor/tailor-latest/bin"
 
 before_install:
   - nvm install 4

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ dependencies:
     - ~/.local/share/coala-bears
     - ~/bakalint-0.4.0
     - ~/.julia
+    - ~/.local/tailor/
   pre:
     - sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial
     - echo 'export PATH=$PATH:~/coala-bears/node_modules/.bin' >> ~/.circlerc
@@ -25,6 +26,7 @@ dependencies:
     - echo 'export PATH=$PATH:~/infer-linux64-v0.7.0/infer/bin' >> ~/.circlerc
     - echo 'export PATH=$PATH:~/pmd-bin-5.4.1/bin' >> ~/.circlerc
     - echo 'export PATH=$PATH:~/bakalint-0.4.0' >> ~/.circlerc
+    - echo 'export PATH=$PATH:~/.local/tailor/tailor-latest/bin' >> ~/.circlerc
     - echo 'export R_LIB_USER=~/.RLibrary' >> ~/.circlerc
     - sed -i '/source \/home\/ubuntu\/virtualenvs\//d' ~/.circlerc
     - mkdir -p ~/.RLibrary


### PR DESCRIPTION
The install.sh provided by tailor installs into /usr/local,
which is not cachable and requires sudo.

Revise the install.sh to install with a PREFIX of ~/.local/,
which places everything into ~/.local/tailor/, with the
version specific components in ~/.local/tailor/tailor-1.9.x/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coala/coala-bears/1142)
<!-- Reviewable:end -->
