### PR TITLE
.travis.yml: Add gfortran to pre-install packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - clang-3.4
       - cppcheck
       - espeak
+      - gfortran
       - ghc
       - haskell-platform
       - indent


### PR DESCRIPTION
gfortran was accidentally removed in the last iteration
of 3df3defa9, and not noticed due to caching.

Fixes https://github.com/coala/coala-bears/issues/1144

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coala/coala-bears/1146)
<!-- Reviewable:end -->
