### PR TITLE
AlexBear.py: Change AlexBear docstring

### DIFF
--- a/bears/natural_language/AlexBear.py
+++ b/bears/natural_language/AlexBear.py
@@ -14,6 +14,9 @@ class AlexBear:
     """
     Checks the markdown file with Alex - Catch insensitive, inconsiderate
     writing.
+
+    Be aware that Alex and this bear only work on English text.
+    For more information, consult <https://www.npmjs.com/package/alex>.
     """
     LANGUAGES = {'Natural Language'}
     REQUIREMENTS = {NpmRequirement('alex', '3')}


### PR DESCRIPTION
The docstring mentions that you should
use only Englis language.
It also includes a link to Alex for
instructions and tests.

Fixes https://github.com/coala/coala-bears/issues/1138