### PR TITLE
XMLBear: Added support for style specifications

### DIFF
--- a/bears/xml2/XMLBear.py
+++ b/bears/xml2/XMLBear.py
@@ -40,21 +40,28 @@ class XMLBear:
     _output_regex = re.compile(
         r'.*:(?P<line>\d+):.*(?P<severity>error|warning)\s?: '
         r'(?P<message>.*)\n.*\n.*')
+    _diff_severity = RESULT_SEVERITY.INFO
 
-    @staticmethod
-    def create_arguments(filename, file, config_file,
+    def create_arguments(self, filename, file, config_file,
                          xml_schema: path='',
-                         xml_dtd: path_or_url=''):
+                         xml_dtd: path_or_url='',
+                         xml_style: str=''):
         """
         :param xml_schema: ``W3C XML Schema`` file used for validation.
         :param xml_dtd:    ``Document type Definition (DTD)`` file or
                            url used for validation.
+        :param xml_style:  ``XML Style Specification`` Relevant args are
+                           c14n, c14n11, exc-c14n and oldxml10.
         """
         args = (filename,)
         if xml_schema:
             args += ('-schema', xml_schema)
         if xml_dtd:
             args += ('-dtdvalid', xml_dtd)
+        styles = ('c14n', 'c14n11', 'exc-c14n', 'oldxml10')
+        if xml_style in styles:
+            args += ('--'+xml_style,)
+            self._diff_severity = RESULT_SEVERITY.MAJOR
 
         return args
 
@@ -68,7 +75,7 @@ class XMLBear:
                     output_regex=self._output_regex),
                 self.process_output_corrected(
                     stdout, filename, file,
-                    diff_severity=RESULT_SEVERITY.INFO,
+                    diff_severity=self._diff_severity,
                     result_message='XML can be formatted better.'))
         else:
             # Return issues from stderr if stdout is empty

--- a/tests/xml2/XMLBearTest.py
+++ b/tests/xml2/XMLBearTest.py
@@ -79,6 +79,13 @@ XMLBearDTDUrlTest = verify_local_bear(
     settings={'xml_dtd': dtd_url},
     tempfile_kwargs={'suffix': '.xml'})
 
+XMLBearStyleTest = verify_local_bear(
+    XMLBear,
+    valid_files=(valid_xml_file,),
+    invalid_files=(invalid_xml_chars,),
+    settings={'xml_style': 'oldxml10'},
+    tempfile_kwargs={'suffix': '.xml'})
+
 
 @generate_skip_decorator(XMLBear)
 class XMLBearSeverityTest(unittest.TestCase):


### PR DESCRIPTION
A format can be specified in the arguments or in the configuration.
The valid args are c14n, c14n11, exc-c14n and oldxml10.

Closes https://github.com/coala/coala-bears/issues/1098