### PR TITLE
.coafile: Enable reSTCheckbear on README.rst

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -37,6 +37,10 @@ enabled = False
 bears = LineCountBear
 max_lines_per_file = 1000
 
+[rst]
+bear = reSTCheckBear
+files = README.rst
+
 [TODOS]
 enabled = False
 bears = KeywordBear


### PR DESCRIPTION
No more broken pypi readmes!

Closes https://github.com/coala/coala-bears/issues/1177