### PR TITLE
.coafile: Enable reSTCheckBEar on all rst files

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -39,7 +39,7 @@ max_lines_per_file = 1000
 
 [rst]
 bear = reSTLintBear
-files = README.rst
+files = **.rst
 
 [TODOS]
 enabled = False


### PR DESCRIPTION
This forces developers to write proper rst files

Closes https://github.com/coala/coala-bears/issues/1182
Related to https://github.com/coala/coala/issues/3044