### PR TITLE
CI: Remove espeak

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -12,7 +12,7 @@ esac
 # apt-get commands
 export DEBIAN_FRONTEND=noninteractive
 
-deps="espeak libclang1-3.4 indent mono-mcs chktex r-base julia golang luarocks verilator cppcheck flawfinder"
+deps="libclang1-3.4 indent mono-mcs chktex r-base julia golang luarocks verilator cppcheck flawfinder"
 
 case $CIRCLE_BUILD_IMAGE in
   "ubuntu-12.04")

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
       - chktex
       - clang-3.4
       - cppcheck
-      - espeak
       - gfortran
       - ghc
       - haskell-platform


### PR DESCRIPTION
espeak is an optional dependency of PyPrint, which
is not used by coala-bears.

Closes https://github.com/coala-analyzer/coala/issues/1939