### PR TITLE
assert_supported_version: Reject Python 3.3.x

### DIFF
--- a/bears/__init__.py
+++ b/bears/__init__.py
@@ -17,6 +17,6 @@ __version__ = VERSION
 
 
 def assert_supported_version():  # pragma: no cover
-    if not sys.version_info > (3, 3):
+    if sys.version_info < (3, 4):
         print('coala supports only python 3.4 or later.')
         exit(4)


### PR DESCRIPTION
The logic in d5f0982 to prevent installation on Python 3.3
was incorrect as Version 3.3.1 is greater than Version 3.3,
so only 3.3.0 was rejected by the current logic.

Fixes https://github.com/coala/coala/issues/3310