### PR TITLE
.travis.yml: Adds build on Python 3.6-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 python:
   - 3.4
   - 3.5
+  - 3.6-dev
 
 dist: trusty
 


### PR DESCRIPTION
Activates a build on Python 3.6 which previously didn't existed.

Closes https://github.com/coala/coala-bears/issues/1170