### PR TITLE
tests: Remove deprecated tests.LocalBearTestHelper

### DIFF
--- a/tests/LocalBearTestHelper.py
+++ b/tests/LocalBearTestHelper.py
@@ -1,6 +1,0 @@
-import logging
-
-logging.warning('This module is deprecated. Use '
-                '`coalib.testing.LocalBearTestHelper` instead.')
-
-from coalib.testing.LocalBearTestHelper import *

--- a/tests/c_languages/CPPCheckBearTest.py
+++ b/tests/c_languages/CPPCheckBearTest.py
@@ -1,5 +1,5 @@
 from bears.c_languages.CPPCheckBear import CPPCheckBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 using namespace std;

--- a/tests/c_languages/CPPCleanBearTest.py
+++ b/tests/c_languages/CPPCleanBearTest.py
@@ -1,5 +1,5 @@
 from bears.c_languages.CPPCleanBear import CPPCleanBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 int main() {

--- a/tests/c_languages/CPPLintBearTest.py
+++ b/tests/c_languages/CPPLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.c_languages.CPPLintBear import CPPLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 test_file = """
 int main() {

--- a/tests/c_languages/CSecurityBearTest.py
+++ b/tests/c_languages/CSecurityBearTest.py
@@ -1,5 +1,5 @@
 from bears.c_languages.CSecurityBear import CSecurityBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 void demo() {

--- a/tests/c_languages/CSharpLintBearTest.py
+++ b/tests/c_languages/CSharpLintBearTest.py
@@ -4,7 +4,7 @@ from shutil import which
 from unittest.case import skipIf
 
 from bears.c_languages.CSharpLintBear import CSharpLintBear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 
 

--- a/tests/c_languages/ClangBearTest.py
+++ b/tests/c_languages/ClangBearTest.py
@@ -1,6 +1,6 @@
 
 from bears.c_languages.ClangBear import ClangBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 ClangBearTest = verify_local_bear(

--- a/tests/c_languages/ClangComplexityBearTest.py
+++ b/tests/c_languages/ClangComplexityBearTest.py
@@ -10,7 +10,7 @@ from coalib.settings.Section import Section
 from bears.c_languages.ClangComplexityBear import (
     ClangComplexityBear)
 from tests.BearTestHelper import generate_skip_decorator
-from tests.LocalBearTestHelper import execute_bear
+from coalib.testing.LocalBearTestHelper import execute_bear
 
 
 @generate_skip_decorator(ClangComplexityBear)

--- a/tests/c_languages/GNUIndentBearTest.py
+++ b/tests/c_languages/GNUIndentBearTest.py
@@ -1,5 +1,5 @@
 from bears.c_languages.GNUIndentBear import GNUIndentBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 test_file1 = """
 int

--- a/tests/cmake/CMakeLintBearTest.py
+++ b/tests/cmake/CMakeLintBearTest.py
@@ -1,7 +1,7 @@
 import os
 
 from bears.cmake.CMakeLintBear import CMakeLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = 'project(FooBar C)\nset(VERSION 0)\n'

--- a/tests/coffee_script/CoffeeLintBearTest.py
+++ b/tests/coffee_script/CoffeeLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.coffee_script.CoffeeLintBear import CoffeeLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 # Lint your CoffeeScript!

--- a/tests/configfiles/DockerfileLintBearTest.py
+++ b/tests/configfiles/DockerfileLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.configfiles.DockerfileLintBear import DockerfileLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 FROM ubuntu:14.04

--- a/tests/configfiles/PuppetLintBearTest.py
+++ b/tests/configfiles/PuppetLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.configfiles.PuppetLintBear import PuppetLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 file { '/some.conf':

--- a/tests/css/CSSAutoPrefixBearTest.py
+++ b/tests/css/CSSAutoPrefixBearTest.py
@@ -1,5 +1,5 @@
 from bears.css.CSSAutoPrefixBear import CSSAutoPrefixBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/css/CSSLintBearTest.py
+++ b/tests/css/CSSLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.css.CSSLintBear import CSSLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 .class {

--- a/tests/dart/DartLintBearTest.py
+++ b/tests/dart/DartLintBearTest.py
@@ -3,7 +3,8 @@ from queue import Queue
 from bears.dart.DartLintBear import DartLintBear
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
-from tests.LocalBearTestHelper import verify_local_bear, LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from tests.BearTestHelper import generate_skip_decorator
 
 

--- a/tests/general/AnnotationBearTest.py
+++ b/tests/general/AnnotationBearTest.py
@@ -7,7 +7,7 @@ from coalib.results.AbsolutePosition import AbsolutePosition
 from coalib.results.HiddenResult import HiddenResult
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
-from tests.LocalBearTestHelper import execute_bear
+from coalib.testing.LocalBearTestHelper import execute_bear
 
 
 class AnnotationBearTest(unittest.TestCase):

--- a/tests/general/FilenameBearTest.py
+++ b/tests/general/FilenameBearTest.py
@@ -1,7 +1,7 @@
 from queue import Queue
 
 from bears.general.FilenameBear import FilenameBear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
 from coalib.settings.Section import Section
 

--- a/tests/general/KeywordBearTest.py
+++ b/tests/general/KeywordBearTest.py
@@ -7,7 +7,7 @@ from coalib.results.HiddenResult import HiddenResult
 from coalib.results.SourceRange import SourceRange
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
-from tests.LocalBearTestHelper import verify_local_bear, execute_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear, execute_bear
 
 test_file = """
 test line fix me

--- a/tests/general/LineCountBearTest.py
+++ b/tests/general/LineCountBearTest.py
@@ -1,7 +1,7 @@
 from queue import Queue
 
 from bears.general.LineCountBear import LineCountBear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.results.Result import RESULT_SEVERITY, Result
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting

--- a/tests/general/LineLengthBearTest.py
+++ b/tests/general/LineLengthBearTest.py
@@ -1,5 +1,5 @@
 from bears.general.LineLengthBear import LineLengthBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 test_file = """
 test

--- a/tests/general/SpaceConsistencyBearTest.py
+++ b/tests/general/SpaceConsistencyBearTest.py
@@ -2,7 +2,7 @@ from queue import Queue
 
 from bears.general.SpaceConsistencyBear import (
     SpaceConsistencyBear, SpacingHelper)
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 

--- a/tests/general/coalaBearTest.py
+++ b/tests/general/coalaBearTest.py
@@ -1,5 +1,5 @@
 from bears.general.coalaBear import coalaBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 coala"""

--- a/tests/go/GoErrCheckBearTest.py
+++ b/tests/go/GoErrCheckBearTest.py
@@ -1,5 +1,5 @@
 from bears.go.GoErrCheckBear import GoErrCheckBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """package main
 import "fmt"

--- a/tests/go/GoImportsBearTest.py
+++ b/tests/go/GoImportsBearTest.py
@@ -1,6 +1,6 @@
 
 from bears.go.GoImportsBear import GoImportsBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """package main
 

--- a/tests/go/GoLintBearTest.py
+++ b/tests/go/GoLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.go.GoLintBear import GoLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 // Test that blank imports in package main are not flagged.

--- a/tests/go/GoReturnsBearTest.py
+++ b/tests/go/GoReturnsBearTest.py
@@ -1,5 +1,5 @@
 from bears.go.GoReturnsBear import GoReturnsBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file1 = """import "errors"
 

--- a/tests/go/GoTypeBearTest.py
+++ b/tests/go/GoTypeBearTest.py
@@ -1,5 +1,5 @@
 from bears.go.GoTypeBear import GoTypeBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/go/GoVetBearTest.py
+++ b/tests/go/GoVetBearTest.py
@@ -4,7 +4,7 @@ from shutil import which
 from unittest.case import skipIf
 
 from bears.go.GoVetBear import GoVetBear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 
 

--- a/tests/go/GofmtBearTest.py
+++ b/tests/go/GofmtBearTest.py
@@ -1,5 +1,5 @@
 from bears.go.GofmtBear import GofmtBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 GofmtBear = verify_local_bear(
     GofmtBear,

--- a/tests/haskell/HaskellLintBearTest.py
+++ b/tests/haskell/HaskellLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.haskell.HaskellLintBear import HaskellLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 myconcat = (++)

--- a/tests/hypertext/BootLintBearTest.py
+++ b/tests/hypertext/BootLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.hypertext.BootLintBear import BootLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/hypertext/HTMLLintBearTest.py
+++ b/tests/hypertext/HTMLLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.hypertext.HTMLLintBear import HTMLLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 test_file = """
 <html>

--- a/tests/java/CheckstyleBearTest.py
+++ b/tests/java/CheckstyleBearTest.py
@@ -5,7 +5,7 @@ from queue import Queue
 
 from bears.java import CheckstyleBear
 from tests.BearTestHelper import generate_skip_decorator
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 

--- a/tests/java/InferBearTest.py
+++ b/tests/java/InferBearTest.py
@@ -1,5 +1,5 @@
 from bears.java.InferBear import InferBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/java/JavaPMDBearTest.py
+++ b/tests/java/JavaPMDBearTest.py
@@ -1,5 +1,5 @@
 from bears.java.JavaPMDBear import JavaPMDBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/jinja2/Jinja2BearTest.py
+++ b/tests/jinja2/Jinja2BearTest.py
@@ -2,7 +2,7 @@ import unittest
 from queue import Queue
 from coalib.settings.Section import Section
 from bears.jinja2.Jinja2Bear import Jinja2Bear
-from tests.LocalBearTestHelper import verify_local_bear, execute_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear, execute_bear
 
 
 Jinja2BearVariableSpacingTest = verify_local_bear(

--- a/tests/js/ESLintBearTest.py
+++ b/tests/js/ESLintBearTest.py
@@ -1,7 +1,7 @@
 import os
 
 from bears.js.ESLintBear import ESLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 test_good = """function addOne(i) {

--- a/tests/js/HappinessLintBearTest.py
+++ b/tests/js/HappinessLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.js.HappinessLintBear import HappinessLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/js/JSComplexityBearTest.py
+++ b/tests/js/JSComplexityBearTest.py
@@ -1,5 +1,5 @@
 from bears.js import JSComplexityBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 complexity_12 = """(function () {
   var foo = 1 && 1 || 0;

--- a/tests/js/JSHintBearTest.py
+++ b/tests/js/JSHintBearTest.py
@@ -1,7 +1,7 @@
 import os
 
 from bears.js.JSHintBear import JSHintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 test_file1 = """
 var name = (function() { return 'Anton' }());

--- a/tests/js/JSONFormatBearTest.py
+++ b/tests/js/JSONFormatBearTest.py
@@ -1,5 +1,5 @@
 from bears.js import JSONFormatBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 test_file1 = """{

--- a/tests/julia/JuliaLintBearTest.py
+++ b/tests/julia/JuliaLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.julia.JuliaLintBear import JuliaLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 a = 2

--- a/tests/latex/LatexLintBearTest.py
+++ b/tests/latex/LatexLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.latex.LatexLintBear import LatexLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/lua/LuaLintBearTest.py
+++ b/tests/lua/LuaLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.lua.LuaLintBear import LuaLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/markdown/MarkdownBearTest.py
+++ b/tests/markdown/MarkdownBearTest.py
@@ -1,5 +1,5 @@
 from bears.markdown.MarkdownBear import MarkdownBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 test_file1 = """1. abc
 1. def

--- a/tests/matlab/MatlabIndentationBearTest.py
+++ b/tests/matlab/MatlabIndentationBearTest.py
@@ -1,5 +1,5 @@
 from bears.matlab.MatlabIndentationBear import MatlabIndentationBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 MatlabIndentationBearTest = verify_local_bear(
     MatlabIndentationBear,

--- a/tests/natural_language/AlexBearTest.py
+++ b/tests/natural_language/AlexBearTest.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from bears.natural_language.AlexBear import AlexBear
 from tests.BearTestHelper import generate_skip_decorator
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = 'Their network looks good.'
 

--- a/tests/natural_language/LanguageToolBearTest.py
+++ b/tests/natural_language/LanguageToolBearTest.py
@@ -4,7 +4,7 @@ from unittest.case import SkipTest
 
 from bears.natural_language.LanguageToolBear import LanguageToolBear
 from tests.BearTestHelper import generate_skip_decorator
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 try:
     import language_check

--- a/tests/natural_language/ProseLintBearTest.py
+++ b/tests/natural_language/ProseLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.natural_language.ProseLintBear import ProseLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = 'The 50s were swell.'
 bad_file = "The 50's were swell."

--- a/tests/natural_language/SpellCheckBearTest.py
+++ b/tests/natural_language/SpellCheckBearTest.py
@@ -2,7 +2,7 @@ import platform
 import unittest
 
 from bears.natural_language.SpellCheckBear import SpellCheckBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = 'This is correct spelling.'
 

--- a/tests/natural_language/WriteGoodLintBearTest.py
+++ b/tests/natural_language/WriteGoodLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.natural_language.WriteGoodLintBear import WriteGoodLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """The 70s era was awesome for music lovers.
 """

--- a/tests/perl/PerlCriticBearTest.py
+++ b/tests/perl/PerlCriticBearTest.py
@@ -1,7 +1,7 @@
 import os
 
 from bears.perl.PerlCriticBear import PerlCriticBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/php/PHPCodeSnifferBearTest.py
+++ b/tests/php/PHPCodeSnifferBearTest.py
@@ -1,5 +1,5 @@
 from bears.php.PHPCodeSnifferBear import PHPCodeSnifferBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """<?php

--- a/tests/php/PHPLintBearTest.py
+++ b/tests/php/PHPLintBearTest.py
@@ -4,7 +4,7 @@ from shutil import which
 from unittest.case import skipIf
 
 from bears.php.PHPLintBear import PHPLintBear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 
 

--- a/tests/python/MypyBearTest.py
+++ b/tests/python/MypyBearTest.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 from bears.python.MypyBear import MypyBear
 from tests.BearTestHelper import generate_skip_decorator
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 from coalib.results.Result import Result

--- a/tests/python/PEP8BearTest.py
+++ b/tests/python/PEP8BearTest.py
@@ -1,7 +1,7 @@
 from queue import Queue
 
 from bears.python.PEP8Bear import PEP8Bear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 

--- a/tests/python/PEP8NotebookBearTest.py
+++ b/tests/python/PEP8NotebookBearTest.py
@@ -1,4 +1,4 @@
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 from bears.python.PEP8NotebookBear import PEP8NotebookBear
 
 

--- a/tests/python/PyCommentedCodeBearTest.py
+++ b/tests/python/PyCommentedCodeBearTest.py
@@ -1,7 +1,7 @@
 from queue import Queue
 
 from bears.python.PyCommentedCodeBear import PyCommentedCodeBear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 
 

--- a/tests/python/PyDocStyleBearTest.py
+++ b/tests/python/PyDocStyleBearTest.py
@@ -1,5 +1,5 @@
 from bears.python.PyDocStyleBear import PyDocStyleBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = '''

--- a/tests/python/PyFlakesBearTest.py
+++ b/tests/python/PyFlakesBearTest.py
@@ -1,5 +1,5 @@
 from bears.python.PyFlakesBear import PyFlakesBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 print("Hi")

--- a/tests/python/PyImportSortBearTest.py
+++ b/tests/python/PyImportSortBearTest.py
@@ -1,5 +1,5 @@
 from bears.python.PyImportSortBear import PyImportSortBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 PyImportSortBearTest = verify_local_bear(PyImportSortBear,
                                          ('import os\nimport sys\n',

--- a/tests/python/PyLintBearTest.py
+++ b/tests/python/PyLintBearTest.py
@@ -5,7 +5,7 @@ from shutil import which
 from unittest.case import skipIf
 
 from bears.python.PyLintBear import PyLintBear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 

--- a/tests/python/PyUnusedCodeBearTest.py
+++ b/tests/python/PyUnusedCodeBearTest.py
@@ -1,5 +1,5 @@
 from bears.python.PyUnusedCodeBear import PyUnusedCodeBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 invalid_imports = """

--- a/tests/python/PycodestyleBearTest.py
+++ b/tests/python/PycodestyleBearTest.py
@@ -1,5 +1,5 @@
 from bears.python.PycodestyleBear import PycodestyleBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = '''

--- a/tests/python/RadonBearTest.py
+++ b/tests/python/RadonBearTest.py
@@ -1,5 +1,5 @@
 from bears.python.RadonBear import RadonBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 test_file1 = """
 def simple():

--- a/tests/python/YapfBearTest.py
+++ b/tests/python/YapfBearTest.py
@@ -3,7 +3,7 @@ from queue import Queue
 from unittest.case import skipIf
 
 from bears.python.YapfBear import YapfBear
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from tests.BearTestHelper import generate_skip_decorator
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting

--- a/tests/python/requirements/PySafetyBearTest.py
+++ b/tests/python/requirements/PySafetyBearTest.py
@@ -5,7 +5,7 @@ from safety.safety import Vulnerability
 
 from bears.python.requirements.PySafetyBear import PySafetyBear, Package
 from coalib.settings.Section import Section
-from tests.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 
 
 class PySafetyBearTest(LocalBearTestHelper):

--- a/tests/r/FormatRBearTest.py
+++ b/tests/r/FormatRBearTest.py
@@ -1,5 +1,5 @@
 from bears.r.FormatRBear import FormatRBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file_1 = """1 + 1
 if (TRUE) {

--- a/tests/r/RLintBearTest.py
+++ b/tests/r/RLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.r.RLintBear import RLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 fun <- function(one){

--- a/tests/rest/RSTcheckBearTest.py
+++ b/tests/rest/RSTcheckBearTest.py
@@ -1,5 +1,5 @@
 from bears.rest.RSTcheckBear import RSTcheckBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 rst_syntax_good = '====\ntest\n====\n'
 rst_syntax_bad = '====\ntest\n===\n'

--- a/tests/rest/reSTLintBearTest.py
+++ b/tests/rest/reSTLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.rest.reSTLintBear import reSTLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = 'test\n====\n'
 bad_file = 'test\n==\n'

--- a/tests/ruby/RuboCopBearTest.py
+++ b/tests/ruby/RuboCopBearTest.py
@@ -1,7 +1,7 @@
 import os
 
 from bears.ruby.RuboCopBear import RuboCopBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """def good_name
   test if something

--- a/tests/ruby/RubySmellBearTest.py
+++ b/tests/ruby/RubySmellBearTest.py
@@ -1,5 +1,5 @@
 from bears.ruby.RubySmellBear import RubySmellBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """# Does something

--- a/tests/ruby/RubySyntaxBearTest.py
+++ b/tests/ruby/RubySyntaxBearTest.py
@@ -1,5 +1,5 @@
 from bears.ruby.RubySyntaxBear import RubySyntaxBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 class HelloWorld

--- a/tests/scala/ScalaLintBearTest.py
+++ b/tests/scala/ScalaLintBearTest.py
@@ -1,7 +1,7 @@
 import os
 
 from bears.scala.ScalaLintBear import ScalaLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 object HelloWorld {

--- a/tests/scss/SCSSLintBearTest.py
+++ b/tests/scss/SCSSLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.scss.SCSSLintBear import SCSSLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/shell/ShellCheckBearTest.py
+++ b/tests/shell/ShellCheckBearTest.py
@@ -1,5 +1,5 @@
 from bears.shell.ShellCheckBear import ShellCheckBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 valid_file = """

--- a/tests/sql/SQLintBearTest.py
+++ b/tests/sql/SQLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.sql.SQLintBear import SQLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 SELECT * FROM table_name;

--- a/tests/swift/TailorBearTest.py
+++ b/tests/swift/TailorBearTest.py
@@ -1,7 +1,7 @@
 import os
 
 from bears.swift.TailorBear import TailorBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 tailorconfig = os.path.join(os.path.dirname(__file__),
                             'test_files',

--- a/tests/typescript/TSLintBearTest.py
+++ b/tests/typescript/TSLintBearTest.py
@@ -1,7 +1,7 @@
 import os
 
 from bears.typescript.TSLintBear import TSLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """function findTitle(title) {
     let titleElement = "hello";

--- a/tests/verilog/VerilogLintBearTest.py
+++ b/tests/verilog/VerilogLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.verilog.VerilogLintBear import VerilogLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 module mux2to1 (w0, w1, s, f);

--- a/tests/vhdl/VHDLLintBearTest.py
+++ b/tests/vhdl/VHDLLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.vhdl.VHDLLintBear import VHDLLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 VHDLLintBearTest = verify_local_bear(VHDLLintBear,

--- a/tests/vimscript/VintBearTest.py
+++ b/tests/vimscript/VintBearTest.py
@@ -1,5 +1,5 @@
 from bears.vimscript.VintBear import VintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 
 good_file = """

--- a/tests/yml/RAMLLintBearTest.py
+++ b/tests/yml/RAMLLintBearTest.py
@@ -1,5 +1,5 @@
 from bears.yml.RAMLLintBear import RAMLLintBear
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = """
 #%RAML 0.8

--- a/tests/yml/YAMLLintBearTest.py
+++ b/tests/yml/YAMLLintBearTest.py
@@ -1,6 +1,6 @@
 from bears.yml.YAMLLintBear import YAMLLintBear
 from coala_utils.ContextManagers import prepare_file
-from tests.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 test_file = """
 ---


### PR DESCRIPTION
tests.LocalBearTestHelper is deprecated in favor of coalib.testing.LocalBearTestHelper. Replaced the import statements and removed the file

Closes https://github.com/coala/coala-bears/issues/1190