### PR TITLE
tests: Removes deprecated tests.BearTestHelper

### DIFF
--- a/tests/BearTestHelper.py
+++ b/tests/BearTestHelper.py
@@ -1,6 +1,0 @@
-import logging
-
-logging.warning('This module is deprecated. Use '
-                '`coalib.testing.BearTestHelper` instead.')
-
-from coalib.testing.BearTestHelper import *

--- a/tests/c_languages/ClangComplexityBearTest.py
+++ b/tests/c_languages/ClangComplexityBearTest.py
@@ -9,7 +9,7 @@ from coalib.settings.Section import Section
 
 from bears.c_languages.ClangComplexityBear import (
     ClangComplexityBear)
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.testing.LocalBearTestHelper import execute_bear
 
 

--- a/tests/c_languages/codeclone_detection/ClangASTPrintBearTest.py
+++ b/tests/c_languages/codeclone_detection/ClangASTPrintBearTest.py
@@ -6,7 +6,7 @@ from clang.cindex import TranslationUnitLoadError
 
 from bears.c_languages.codeclone_detection.ClangASTPrintBear import (
     ClangASTPrintBear)
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.settings.Section import Section
 
 

--- a/tests/c_languages/codeclone_detection/ClangCloneDetectionBearTest.py
+++ b/tests/c_languages/codeclone_detection/ClangCloneDetectionBearTest.py
@@ -6,7 +6,7 @@ from bears.c_languages.codeclone_detection.ClangCloneDetectionBear import (
     ClangCloneDetectionBear)
 from bears.c_languages.codeclone_detection.ClangFunctionDifferenceBear import (
     ClangFunctionDifferenceBear)
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 

--- a/tests/dart/DartLintBearTest.py
+++ b/tests/dart/DartLintBearTest.py
@@ -5,7 +5,7 @@ from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 from coalib.testing.LocalBearTestHelper import verify_local_bear
 from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 
 
 good_file = """

--- a/tests/general/CPDBearTest.py
+++ b/tests/general/CPDBearTest.py
@@ -5,7 +5,7 @@ from queue import Queue
 
 
 from bears.general.CPDBear import CPDBear
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 

--- a/tests/java/CheckstyleBearTest.py
+++ b/tests/java/CheckstyleBearTest.py
@@ -4,7 +4,7 @@ from tempfile import NamedTemporaryFile
 from queue import Queue
 
 from bears.java import CheckstyleBear
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting

--- a/tests/natural_language/AlexBearTest.py
+++ b/tests/natural_language/AlexBearTest.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from bears.natural_language.AlexBear import AlexBear
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 good_file = 'Their network looks good.'

--- a/tests/natural_language/LanguageToolBearTest.py
+++ b/tests/natural_language/LanguageToolBearTest.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.case import SkipTest
 
 from bears.natural_language.LanguageToolBear import LanguageToolBear
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.testing.LocalBearTestHelper import verify_local_bear
 
 try:

--- a/tests/python/MypyBearTest.py
+++ b/tests/python/MypyBearTest.py
@@ -2,7 +2,7 @@ from queue import Queue
 from textwrap import dedent
 
 from bears.python.MypyBear import MypyBear
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting

--- a/tests/python/YapfBearTest.py
+++ b/tests/python/YapfBearTest.py
@@ -4,7 +4,7 @@ from unittest.case import skipIf
 
 from bears.python.YapfBear import YapfBear
 from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -7,7 +7,7 @@ import unittest.mock
 from queue import Queue
 from tempfile import mkdtemp
 
-from tests.BearTestHelper import generate_skip_decorator
+from coalib.testing.BearTestHelper import generate_skip_decorator
 from bears.vcs.git.GitCommitBear import GitCommitBear
 from coala_utils.string_processing.Core import escape
 from coalib.misc.Shell import run_shell_command


### PR DESCRIPTION
This change removes tests/BearTestHelper.py
and it's usage in importing in other
test files

Fixes #1195