### PR TITLE
Fixed a test as part of PR #1194

### DIFF
--- a/tests/dart/DartLintBearTest.py
+++ b/tests/dart/DartLintBearTest.py
@@ -7,7 +7,6 @@ from coalib.testing.LocalBearTestHelper import verify_local_bear
 from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.testing.BearTestHelper import generate_skip_decorator
 
-
 good_file = """
 printNumber(num aNumber) {
   print('The number is $aNumber.');
@@ -46,7 +45,7 @@ class DartLintBearConfigTest(LocalBearTestHelper):
         section.append(Setting('use_spaces', False))
         bear = DartLintBear(section, Queue())
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(AssertionError, 'Value error'):
             self.check_validity(bear, [], good_file)
 
     def test_config_failure_wrong_indent_size(self):
@@ -54,5 +53,5 @@ class DartLintBearConfigTest(LocalBearTestHelper):
         section.append(Setting('indent_size', 3))
         bear = DartLintBear(section, Queue())
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(AssertionError, 'Value error'):
             self.check_validity(bear, [], good_file)


### PR DESCRIPTION
I have replaced assertRaises() with assertRaisesRegex() for the DartLintBear script [found in tests/dart/DartLintBearTest.py].

Done as a part of GCI, [link to GCI Task](https://codein.withgoogle.com/dashboard/task-instances/6223930375274496/)

Fixes a part of https://github.com/coala/coala-bears/issues/1194
[There are 6 cases to be replaced, 1 was done by @jayvdb and this would be the next one.]
[I am only doing one because, I want more of you guys to code for it and the GCI task does'not allow me too.]

So please review and merge guys happy coding :)