### PR TITLE
ClangComplexityBearTest.py: Change `assertRaises()`

### DIFF
--- a/tests/c_languages/ClangComplexityBearTest.py
+++ b/tests/c_languages/ClangComplexityBearTest.py
@@ -92,5 +92,5 @@ class ClangComplexityBearTest(unittest.TestCase):
 
         generator = self.bear.execute('not_existing', self.file)
         self.assertNotEqual(generator, None)
-        with self.assertRaises(TranslationUnitLoadError):
+        with self.assertRaisesRegex(TranslationUnitLoadError, 'C value error'):
             yield generator


### PR DESCRIPTION
I have replaced assertRaises() with assertRaisesRegex() for the ClangComplexityBearTest script

Done as a part of GCI, [link to GCI Task](https://codein.withgoogle.com/dashboard/task-instances/6223930375274496/)

Fixes a part of #1194
[There are 6 cases to be replaced, 1 was done by @jayvdb and this would be the next one.]
[I am only doing one because, I want more of you guys to code for it and the GCI task does'not allow me too.]

So please review and merge guys happy coding :)