### PR TITLE
DartLintBearTest: Use `assertRaisesRegex` to validate returned error

### DIFF
--- a/tests/dart/DartLintBearTest.py
+++ b/tests/dart/DartLintBearTest.py
@@ -41,12 +41,15 @@ DartLintBearTest = verify_local_bear(DartLintBear,
 @generate_skip_decorator(DartLintBear)
 class DartLintBearConfigTest(LocalBearTestHelper):
 
+    DART_VALUE_ERROR_RE = ('ValueError: DartLintBear only supports '
+                           '`use_spaces=True` and `indent_size=2`')
+
     def test_config_failure_use_spaces(self):
         section = Section('name')
         section.append(Setting('use_spaces', False))
         bear = DartLintBear(section, Queue())
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(AssertionError, self.DART_VALUE_ERROR_RE):
             self.check_validity(bear, [], good_file)
 
     def test_config_failure_wrong_indent_size(self):
@@ -54,5 +57,5 @@ class DartLintBearConfigTest(LocalBearTestHelper):
         section.append(Setting('indent_size', 3))
         bear = DartLintBear(section, Queue())
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(AssertionError, self.DART_VALUE_ERROR_RE):
             self.check_validity(bear, [], good_file)


### PR DESCRIPTION
`assertRaisesRegex` is used over `assertRaises` to validate the error
message to confirm the type of error that occured during execution.

Related to https://github.com/coala/coala-bears/issues/1194