### PR TITLE
InvalidLinkBear.py: Increase default_timeout value

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -16,7 +16,7 @@ from coalib.settings.Setting import typed_dict
 
 
 class InvalidLinkBear(LocalBear):
-    DEFAULT_TIMEOUT = 2
+    DEFAULT_TIMEOUT = 15
     LANGUAGES = {'All'}
     REQUIREMENTS = {PipRequirement('requests', '2.12')}
     AUTHORS = {'The coala developers'}

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -234,7 +234,7 @@ class InvalidLinkBearTest(unittest.TestCase):
     def test_variable_timeouts(self):
         nt = {
             'https://google.com/timeout/test/2/3/4/5/something': 10,
-            'https://facebook.com/timeout': 15
+            'https://facebook.com/timeout': 2
         }
 
         file_contents = """
@@ -256,9 +256,9 @@ class InvalidLinkBearTest(unittest.TestCase):
                               for x in list(uut.run('file', file_contents,
                                                     network_timeout=nt))], [])
             mock.assert_has_calls([
-                unittest.mock.call('https://facebook.com/', timeout=15,
+                unittest.mock.call('https://facebook.com/', timeout=2,
                                    allow_redirects=False),
                 unittest.mock.call('https://google.com/',
                                    timeout=10, allow_redirects=False),
                 unittest.mock.call('https://coala.io/som/thingg/page/123',
-                                   timeout=2, allow_redirects=False)])
+                                   timeout=15, allow_redirects=False)])


### PR DESCRIPTION
Increase default_timeout value to 15. Change corresponding values in
test file (InvalidLinkBearTest.py) to 15 as well

Fixes https://github.com/coala/coala-bears/issues/1219

Additional: 
- [x] lets change the facebook timeout to 2 just so we don't have a redundant testcase.

## Checklist
- [x]  I have gone through the commit guidelines and I've followed them.
- [x]  I have followed the guidelines for the commit shortlog.
- [x]  I have followed the guidelines for the commit body.
- [x]  I have included the issue URL with the 'Fixes' keyword if the commit fixes a real bug and the - [ ]  - - [ ]  'Closes' keyword if it adds a feature or enhancement. For details, check the issue reference section in our commit guidelines.
- [x]  I have run all the tests and they all pass. If any CI (below) is not green, please fix them. If GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!