### PR TITLE
requirements.txt: Remove dependency_management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ coala>=0.10.0.dev20161217232433
 # Dependencies inherited from coala
 # libclang-py3
 # coala_utils
+# dependency_management
 munkres3~=1.0
 pylint~=1.6
 autopep8~=1.2
@@ -32,4 +33,3 @@ scspell3k~=2.0
 mypy-lang~=0.4.6
 rstcheck~=2.2
 safety~=0.5.1
-dependency_management~=0.1.6


### PR DESCRIPTION
dependency_management is already required by coala,
and the versions required are now out of sync.