### PR TITLE
PycodestyleBear: Require pycodestyle 2.2

### DIFF
--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -12,7 +12,7 @@ class PycodestyleBear:
     A wrapper for the tool ``pycodestyle`` formerly known as ``pep8``.
     """
     LANGUAGES = {'Python', 'Python 2', 'Python 3'}
-    REQUIREMENTS = {PipRequirement('pycodestyle')}
+    REQUIREMENTS = {PipRequirement('pycodestyle', '2.2')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ coala>=0.10.0.dev20161217232433
 munkres3~=1.0
 pylint~=1.6
 autopep8~=1.2
+pycodestyle~=2.2
 eradicate~=0.1.6
 autoflake~=0.6.6
 restructuredtext-lint~=0.17.2


### PR DESCRIPTION
PycodestyleBear was added (90043806) without an explicit
entry in requirements.txt, so it inherited the requirement
pycodestyle>=2.2 from autopep8.