### PR TITLE
KeywordBear.py: Add optional regex_keyword param

### DIFF
--- a/tests/general/KeywordBearTest.py
+++ b/tests/general/KeywordBearTest.py
@@ -185,3 +185,32 @@ class KeywordBearDiffTest(unittest.TestCase):
                              '+/*\n'
                              ' test\n'
                              ' */\n')
+
+    def test_keyword_regex(self):
+        text = ['# add two given values and result the result\n',
+                'def add(a, b):',
+                '    return a+b\n',
+                '               \n',
+                'print(add(2, 3))\n']
+
+        regex_keyword = 'r.s.l.'
+
+        with execute_bear(self.uut, filename='F', file=text,
+                          regex_keyword=regex_keyword,
+                          dependency_results=self.dep_results) as result:
+            self.assertEqual(result[0].message, 'The line contains the keyword'
+                                                " 'result' which resulted in a"
+                                                ' match with given regex.')
+
+        text = ['# bla bla bla',
+                'Issue #123',
+                'bla bla bla']
+
+        regex_keyword = '[iI]ssue #[1-9][0-9]*'
+
+        with execute_bear(self.uut, filename='F', file=text,
+                          regex_keyword=regex_keyword,
+                          dependency_results=self.dep_results) as result:
+            self.assertEqual(result[0].message, 'The line contains the keyword'
+                                                " 'Issue #123' which resulted "
+                                                'in a match with given regex.')


### PR DESCRIPTION
Ensures that keywords within a file can be matched against
a user defined regex. A testcase is also added in KeywordBearTest.py
for this feature.

Closes https://github.com/coala/coala-bears/issues/311