### PR TITLE
InvalidLinkBear.py: Increase default_timeout value

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -12,7 +12,7 @@ from coalib.bearlib import deprecate_settings
 
 
 class InvalidLinkBear(LocalBear):
-    DEFAULT_TIMEOUT = 2
+    DEFAULT_TIMEOUT = 15
     LANGUAGES = {'All'}
     REQUIREMENTS = {PipRequirement('requests', '2.12')}
     AUTHORS = {'The coala developers'}


### PR DESCRIPTION
Increase default_timeout value to 15.

Fixes https://github.com/coala/coala-bears/issues/1219

(manually cherry picked from commit 4f26f4c0c)