### PR TITLE
RadonBear: Pin to version 1.4.0

### DIFF
--- a/.ci/generate_bear_requirements.py
+++ b/.ci/generate_bear_requirements.py
@@ -29,6 +29,10 @@ PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 PROJECT_BEAR_DIR = os.path.abspath(os.path.join(PROJECT_DIR, 'bears'))
 
+PINNED_PACKAGES = (
+   'radon',
+)
+
 
 def get_args():
     parser = argparse.ArgumentParser(
@@ -71,8 +75,10 @@ def get_all_pip_requirements(bears):
 def write_requirements(requirements, output):
     for requirement in requirements:
         if requirement.version:
-            output.write(requirement.package + '~=' + requirement.version +
-                         '\n')
+            marker = '==' if requirement.package in PINNED_PACKAGES else '~='
+            output.write('{0}{1}{2}\n'.format(requirement.package,
+                                              marker,
+                                              requirement.version))
         else:
             output.write(requirement.package + '\n')
 

--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -16,10 +16,10 @@ nltk~=3.2
 proselint~=0.7.0
 pycodestyle~=2.2
 pydocstyle~=1.1
-pyflakes~=1.3.0
+pyflakes~=1.4.0
 pylint~=1.6
 pyyaml~=3.12
-radon~=1.4
+radon==1.4.0
 requests~=2.12
 restructuredtext-lint~=0.17.2
 rstcheck~=2.2

--- a/bears/python/PyFlakesBear.py
+++ b/bears/python/PyFlakesBear.py
@@ -18,7 +18,7 @@ class PyFlakesBear:
     See https://github.com/PyCQA/pyflakes for more info.
     """
     LANGUAGES = {'Python', 'Python 3'}
-    REQUIREMENTS = {PipRequirement('pyflakes', '1.3.0')}
+    REQUIREMENTS = {PipRequirement('pyflakes', '1.4.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'

--- a/bears/python/RadonBear.py
+++ b/bears/python/RadonBear.py
@@ -11,7 +11,7 @@ from coalib.settings.Setting import typed_list
 
 class RadonBear(LocalBear):
     LANGUAGES = {'Python', 'Python 2', 'Python 3'}
-    REQUIREMENTS = {PipRequirement('radon', '1.4')}
+    REQUIREMENTS = {PipRequirement('radon', '1.4.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'


### PR DESCRIPTION
radon 1.4.2 added a dependency on flake8-polyfill, which depends
on flake8 without any version specification, and flake8 versions
have various version dependencies on pyflakes and pycodestyle.
As a result, it is not possible to know what versions of pyflakes
and pycodestyle that will be required to be compatible with
whatever flake8 version happens to be installed.

Fixes https://github.com/coala/coala-bears/issues/1228