### PR TITLE
PycodestyleBear: Require pycodestyle 2.2

### DIFF
--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -12,7 +12,7 @@ class PycodestyleBear:
     A wrapper for the tool ``pycodestyle`` formerly known as ``pep8``.
     """
     LANGUAGES = {'Python', 'Python 2', 'Python 3'}
-    REQUIREMENTS = {PipRequirement('pycodestyle')}
+    REQUIREMENTS = {PipRequirement('pycodestyle', '2.2')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ coala~=0.9.1
 munkres3~=1.0
 pylint~=1.6
 autopep8~=1.2
+pycodestyle~=2.2
 eradicate~=0.1
 autoflake~=0.6
 restructuredtext_lint~=0.17


### PR DESCRIPTION
PycodestyleBear was added (90043806) without an explicit
entry in requirements.txt, so it inherited the requirement
pycodestyle>=2.2 from autopep8.

(manually cherry picked from commit d8be55a)