### PR TITLE
HaskellLintBear.py: Add multiple line diff message workaround

### DIFF
--- a/bears/haskell/HaskellLintBear.py
+++ b/bears/haskell/HaskellLintBear.py
@@ -38,11 +38,15 @@ class HaskellLintBear:
         output = json.loads(output)
 
         for issue in output:
-            assert issue['startLine'] == issue['endLine']
             diff = Diff(file)
+            from_lines = issue['from'].splitlines()
+            to_lines = issue['to'].splitlines()
+            assert len(from_lines) == len(to_lines)
+            for other_lines in range(1, len(from_lines)):
+                assert from_lines[other_lines] == to_lines[other_lines]
             line_nr = issue['startLine']
             line_to_change = file[line_nr-1]
-            newline = line_to_change.replace(issue['from'], issue['to'])
+            newline = line_to_change.replace(from_lines[0], to_lines[0])
             diff.change_line(line_nr, line_to_change, newline)
 
             yield Result.from_values(
@@ -51,4 +55,7 @@ class HaskellLintBear:
                 file=filename,
                 severity=self.severity_map[issue['severity']],
                 line=issue['startLine'],
+                column=issue['startColumn'],
+                end_line=issue['endLine'],
+                end_column=issue['endColumn'],
                 diffs={filename: diff})

--- a/tests/haskell/HaskellLintBearTest.py
+++ b/tests/haskell/HaskellLintBearTest.py
@@ -1,15 +1,71 @@
+from queue import Queue
+
 from bears.haskell.HaskellLintBear import HaskellLintBear
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.testing.LocalBearTestHelper import verify_local_bear
+from coalib.testing.BearTestHelper import generate_skip_decorator
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
 
-good_file = """
+good_single_line_file = """
 myconcat = (++)
-"""
+""".splitlines()
 
-bad_file = """
+bad_single_line_file = """
 myconcat a b = ((++) a b)
-"""
+""".splitlines()
 
-HaskellLintBearTest = verify_local_bear(HaskellLintBear,
-                                        valid_files=(good_file,),
-                                        invalid_files=(bad_file,),
-                                        tempfile_kwargs={'suffix': '.hs'})
+good_multiple_line_file = """
+import qualified Data.ByteString.Char8 as BS
+
+
+main :: IO()
+main =
+    return $ BS.concat
+        [ BS.pack "I am being tested by hlint!"
+        , "String dummy"
+        , "Another String dummy"
+        ]
+""".splitlines()
+
+bad_multiple_line_file = """
+import qualified Data.ByteString.Char8 as BS
+
+
+main :: IO()
+main =
+    return $ BS.concat $
+        [ BS.pack $ "I am being tested by hlint!"
+        , "String dummy"
+        , "Another String dummy"
+        ]
+""".splitlines()
+
+
+@generate_skip_decorator(HaskellLintBear)
+class HaskellLintBearTest(LocalBearTestHelper):
+
+    def setUp(self):
+        self.section = Section('name')
+        self.uut = HaskellLintBear(self.section, Queue())
+
+    def test_valid(self):
+        self.check_validity(self.uut, good_single_line_file, valid=True,
+                            tempfile_kwargs={'suffix': '.hs'})
+        self.check_validity(self.uut, good_multiple_line_file, valid=True,
+                            tempfile_kwargs={'suffix': '.hs'})
+
+    def test_invalid(self):
+        results = self.check_validity(self.uut, bad_single_line_file,
+                                      valid=False,
+                                      tempfile_kwargs={'suffix': '.hs'})
+        self.assertEqual(len(results), 1, str(results))
+        self.assertIn('Redundant bracket',
+                      results[0].message)
+
+        results = self.check_validity(self.uut, bad_multiple_line_file,
+                                      valid=False,
+                                      tempfile_kwargs={'suffix': '.hs'})
+        self.assertEqual(len(results), 2, str(results))
+        self.assertIn('Redundant $',
+                      results[0].message)


### PR DESCRIPTION
Add multiple line diff message to be handled properly, atleast
when only the first line of `hlint` output is different (which is the
case in most cases)

Closes https://github.com/coala/coala-bears/pull/1276