### PR TITLE
MarkdownBear: Add remark-validate-links plugin

### DIFF
--- a/bears/markdown/MarkdownBear.py
+++ b/bears/markdown/MarkdownBear.py
@@ -28,7 +28,7 @@ class MarkdownBear:
 
     _output_regex = re.compile(
         r'\s*(?P<line>\d+):(?P<column>\d+)'
-        r'\s*(?P<severity>warning)\s*(?P<message>.*)')
+        r'\s*(?P<severity>warning)\s*(?P<message>(?:\S|\s(?!\s))*)')
 
     @staticmethod
     @deprecate_settings(bullets='markdown_bullets',
@@ -126,16 +126,17 @@ class MarkdownBear:
             'ruleSpaces': horizontal_rule_spaces,       # Bool
             'ruleRepetition': horizontal_rule_repeat,   # int
         }
-        remark_configs_plugins = {
+        remark_lint_configs = {
             'maximumLineLength': max_line_length        # int
         }
 
         config_json = json.dumps(remark_configs_settings)
         # Remove { and } as remark adds them on its own
         settings = config_json[1:-1]
-        config_json = json.dumps(remark_configs_plugins)
-        plugins = 'lint=' + config_json[1:-1]
-        return '--no-color', '--quiet', '--setting', settings, '--use', plugins
+        config_json = json.dumps(remark_lint_configs)
+        lint = 'lint=' + config_json[1:-1]
+        return (filename, '--no-color', '--quiet', '--setting', settings,
+                '--use', lint, '--use', 'validate-links')
 
     def process_output(self, output, filename, file):
         stdout, stderr = output

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "postcss-cli": "~2",
     "remark-cli": "~2",
     "remark-lint": ">=5.1.0",
+    "remark-validate-links": "~5.0.0",
     "tslint": "~3",
     "typescript": ">=1.7.3",
     "ramllint": "~1.2.2",

--- a/tests/markdown/MarkdownBearTest.py
+++ b/tests/markdown/MarkdownBearTest.py
@@ -1,5 +1,11 @@
+import unittest
+from queue import Queue
+
 from bears.markdown.MarkdownBear import MarkdownBear
-from coalib.testing.LocalBearTestHelper import verify_local_bear
+from coalib.testing.BearTestHelper import generate_skip_decorator
+from coalib.testing.LocalBearTestHelper import verify_local_bear, execute_bear
+from coalib.settings.Section import Section
+from coala_utils.ContextManagers import prepare_file
 
 test_file1 = """1. abc
 1. def
@@ -12,6 +18,16 @@ test_file2 = """1. abc
 
 test_file3 = """1. abcdefghijklm
 2. nopqrstuvwxyz
+"""
+
+test_file4 = """# Hello
+
+Read more [This does not exist](#world).
+"""
+
+test_file5 = """# World
+
+Read more [This exists](#world).
 """
 
 MarkdownBearTest = verify_local_bear(MarkdownBear,
@@ -29,3 +45,22 @@ MarkdownBearMaxLineLengthSettingTest = verify_local_bear(
     valid_files=(test_file2,),
     invalid_files=(test_file3,),
     settings={'max_line_length': 10})
+
+MarkdownBearValidateLinksTest = verify_local_bear(
+    MarkdownBear,
+    valid_files=(test_file5,),
+    invalid_files=(test_file4,))
+
+
+@generate_skip_decorator(MarkdownBear)
+class MarkdownBearValidateLinksResultMessageTest(unittest.TestCase):
+
+    def setUp(self):
+        self.uut = MarkdownBear(Section('name'), Queue())
+
+    def test_validate_links_message(self):
+        content = test_file4.splitlines()
+        with prepare_file(content, None) as (file, fname):
+            with execute_bear(self.uut, fname, file) as results:
+                self.assertEqual(results[0].message,
+                                 'Link to unknown heading: `world`')


### PR DESCRIPTION
Remark plugin to validate if links to headings and files in markdown point to existing things.

Closes https://github.com/coala/coala-bears/issues/924