### PR TITLE
LanguageToolBear.py: Resolve settings conflict

### DIFF
--- a/bears/natural_language/LanguageToolBear.py
+++ b/bears/natural_language/LanguageToolBear.py
@@ -33,16 +33,16 @@ class LanguageToolBear(LocalBear):
             except ImportError:  # pragma: no cover
                 return 'Please install the `language-check` pip package.'
 
-    @deprecate_settings(language='locale')
+    @deprecate_settings(natural_language=('language', 'locale'))
     def run(self,
             filename,
             file,
-            language: str='auto',
+            natural_language: str='auto',
             languagetool_disable_rules: typed_list(str)=()):
         '''
         Checks the code with LanguageTool.
 
-        :param language:                   A locale representing the language
+        :param natural_language:           A locale representing the language
                                            you want to have checked. If set to
                                            'auto' the language is guessed.
                                            If the language cannot be guessed,
@@ -54,11 +54,13 @@ class LanguageToolBear(LocalBear):
         from language_check import LanguageTool, correct
 
         joined_text = ''.join(file)
-        language = (guess_language(joined_text)
-                    if language == 'auto' else language)
-        language = 'en-US' if not language else language
+        natural_language = (guess_language(joined_text)
+                            if natural_language == 'auto'
+                            else natural_language)
+        natural_language = 'en-US' if not natural_language \
+                           else natural_language
 
-        tool = LanguageTool(language, motherTongue='en_US')
+        tool = LanguageTool(natural_language, motherTongue='en_US')
         tool.disabled.update(languagetool_disable_rules)
 
         matches = tool.check(joined_text)

--- a/tests/natural_language/LanguageToolBearTest.py
+++ b/tests/natural_language/LanguageToolBearTest.py
@@ -27,7 +27,7 @@ LanguageToolBearLanguageTest = verify_local_bear(
     LanguageToolBear,
     valid_files=('A correct English sentence sounds nice to everyone.',),
     invalid_files=('Ein korrekter englischer Satz klingt für alle gut.',),
-    settings={'language': 'en-US'})
+    settings={'natural_language': 'en-US'})
 
 
 LanguageToolBearDisableRulesTest = verify_local_bear(
@@ -37,6 +37,20 @@ LanguageToolBearDisableRulesTest = verify_local_bear(
                  'A line beginning with uppercase.'),
     invalid_files=('  Line with unnecessary spaces at the start.',),
     settings={'languagetool_disable_rules': 'UPPERCASE_SENTENCE_START'})
+
+
+LanguageToolBearDeprecatedSettingTest1 = verify_local_bear(
+    LanguageToolBear,
+    valid_files=('A correct English sentence sounds nice to everyone.',),
+    invalid_files=('Ein korrekter englischer Satz klingt für alle gut.',),
+    settings={'language': 'en-US'})
+
+
+LanguageToolBearDeprecatedSettingTest2 = verify_local_bear(
+    LanguageToolBear,
+    valid_files=('A correct English sentence sounds nice to everyone.',),
+    invalid_files=('Ein korrekter englischer Satz klingt für alle gut.',),
+    settings={'locale': 'en-US'})
 
 
 @generate_skip_decorator(LanguageToolBear)


### PR DESCRIPTION
Rename setting `language` to `natural_language`
in LanguageToolBear.py to resolve conflict

Closes https://github.com/coala/coala-bears/issues/1137