### PR TITLE
.travis.yml: Exclude branch 'sils/*'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,3 +132,7 @@ script:
 
 notifications:
   email: false
+
+branches:
+  exclude:
+    - /^sils\//


### PR DESCRIPTION
Turns the travis builds off for branch 'sils/*'
to prevent redundant builds.

Closes https://github.com/coala/coala-bears/issues/1285