### PR TITLE
AnnotationBear.py: Corrects typo in docstring

### DIFF
--- a/bears/general/AnnotationBear.py
+++ b/bears/general/AnnotationBear.py
@@ -79,16 +79,16 @@ class AnnotationBear(LocalBear):
             A dictionary containing the various ways to  define single-line
             strings in a language.
         :param multiline_string_delimiters:
-            A dictionary contatining the various ways to define multi-line
+            A dictionary containing the various ways to define multi-line
             strings in a language.
         :param comment_delimiter:
-            A dictionary contatining the various ways to define single-line
+            A dictionary containing the various ways to define single-line
             comments in a language.
         :param multiline_comment_delimiters:
-            A dictionary contatining the various ways to define multi-line
+            A dictionary containing the various ways to define multi-line
             comments in a language.
         :return:
-            Two tuples first contatining a tuple of strings, the second a tuple
+            Two tuples first containing a tuple of strings, the second a tuple
             of comments.
         """
         text = ''.join(file)


### PR DESCRIPTION
Changes the four occurences of contatining into containing, in
the docstring of function find_annotation_ranges.

Fixes https://github.com/coala/coala-bears/issues/1293