### PR TITLE
InvalidLinkBear.py: Edit Regex

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -73,6 +73,13 @@ class InvalidLinkBear(LocalBear):
                                         # set of parenthesis.
                                         # An example can be:
                                         # http://wik.org/Hello_(Adele_song)/200
+            |                           # OR
+                /[^\s()\'"`<>|\\]*      # Path name present after `/`
+                                        # This part allows path names that
+                                        # come after `/` to contain
+                                        # `%` symbol.
+                                        # An example:
+                                        # http://www.example.com/abc%123
             )
             *)
                                         # Thus, the whole part above

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -86,6 +86,9 @@ class InvalidLinkBearTest(unittest.TestCase):
         # Parentheses
         https://en.wikipedia.org/wiki/Hello_(Adele_song)/200
 
+        # Percentage after forward slash
+        https://img.shields.io/badge/Maintained%3F-yes-green.svg
+
         # Quotes
         "https://github.com/coala/coala-bears/issues/200"
         'http://httpbin.org/status/203'


### PR DESCRIPTION
Adds a class to the regex, to allow
% symbol to exist after / in
the URL

Fixes https://github.com/coala/coala-bears/issues/1290