### PR TITLE
AppveyorCI: Remove astroid upgrade as not required

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -50,7 +50,6 @@ install:
   - "%CMD_IN_ENV% pip wheel --use-wheel --wheel-dir C:\\wheels --find-links C:\\wheels -r requirements.txt"
   - "%CMD_IN_ENV% pip install --find-links=C:\\wheels -r test-requirements.txt"
   - "%CMD_IN_ENV% pip install --find-links=C:\\wheels -r requirements.txt"
-  - "%CMD_IN_ENV% pip install --upgrade astroid"
   - "CALL .ci/deps.nltk.cmd"
 
   - ps: "Install-Product node ''"  # Use latest node v5.x.x


### PR DESCRIPTION
This line was copied from coala in 6875fad64
but it is no longer required.