### PR TITLE
InvalidLinkBear.py: Edit Regex

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -62,17 +62,24 @@ class InvalidLinkBear(LocalBear):
             [^.:%\s_/?#[\]@\\]+         # Initial part of domain
             \.                          # A required dot `.`
             (
-                (?:[^\s()%\'"`<>|\\]+)  # Path name
+                (?:[^\s()%\/'"`<>|\\]+) # Path name
                                         # This part does not allow
                                         # any parenthesis: balanced or
                                         # unbalanced.
             |                           # OR
-                \([^\s()%\'"`<>|\\]*\)  # Path name contained within ()
+                \([^\s()%\/'"`<>|\\]*\) # Path name contained within ()
                                         # This part allows path names that
                                         # are explicitly enclosed within one
                                         # set of parenthesis.
                                         # An example can be:
                                         # http://wik.org/Hello_(Adele_song)/200
+            |                           # OR
+                /[^\s()\'"`<>|\\]*      # Path name present after `/`
+                                        # This part allows path names that
+                                        # come after `/` to contain
+                                        # `%` symbol.
+                                        # An example:
+                                        # http://www.example.com/abc%123
             )
             *)
                                         # Thus, the whole part above

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -86,6 +86,9 @@ class InvalidLinkBearTest(unittest.TestCase):
         # Parentheses
         https://en.wikipedia.org/wiki/Hello_(Adele_song)/200
 
+        # Percentage after forward slash
+        http://example.com/123%abc
+
         # Quotes
         "https://github.com/coala/coala-bears/issues/200"
         'http://httpbin.org/status/203'


### PR DESCRIPTION
Adds a class to the regex, to allow
% symbol to exist after / in
the URL

Fixes #1290