### PR TITLE
GitCommitBear.py: Enforce fullmatch on body_regex

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -31,6 +31,10 @@ bears = SpaceConsistencyBear
 bears = GitCommitBear
 shortlog_trailing_period = False
 shortlog_regex = ([^:]*|[^:]+: [A-Z0-9*].*)
+body_close_issue = True
+body_close_issue_full_url = True
+body_close_issue_last_line = True
+body_enforce_issue_reference = False
 
 [LineCounting]
 enabled = False

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -304,7 +304,7 @@ class GitCommitBear(GlobalBear):
                 r'https?://{}\S+/issues/(\S+)'.format(re.escape(host)))
         else:
             result_info = 'issue'
-            issue_ref_regex = r'#(\S+)'
+            issue_ref_regex = r'(?:\w+/\w+)?#(\S+)'
 
         concat_regex = '|'.join(kw for kw in self.CONCATENATION_KEYWORDS)
         compiled_joint_regex = re.compile(

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -241,7 +241,7 @@ class GitCommitBear(GlobalBear):
                                'HEAD commit. Please add one.')
             return
 
-        if body_regex and not re.search(body_regex, body):
+        if body_regex and not re.fullmatch(body_regex, body.strip()):
             yield Result(self, 'No match found in commit message for the '
                                'regular expression provided: %s' % body_regex)
 

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -257,21 +257,21 @@ class GitCommitBear(GlobalBear):
     def check_issue_reference(self, body,
                               body_close_issue: bool=False,
                               body_close_issue_full_url: bool=False,
-                              body_close_issue_on_last_line: bool=False):
+                              body_close_issue_on_last_line: bool=False,
+                              body_enforce_issue_reference: bool=False):
         """
         Check for matching issue related references and URLs.
 
         :param body:
             Body of the commit message of HEAD.
         :param body_close_issue:
-            Whether to check for the presence of issue reference within
-            the commit body by retrieving host information from git
-            configuration. GitHub and GitLab support auto closing issues with
-            commit messages. Checks for matching keywords in the commit body.
-            By default, if none of ``body_close_issue_full_url`` and
-            ``body_close_issue_on_last_line`` are enabled, checks for presence
-            of short references like ``closes #213``. Otherwise behaves
-            according to other chosen flags.
+            GitHub and GitLab support auto closing issues with
+            commit messages. When enabled, this checks for matching keywords
+            in the commit body by retrieving host information from git
+            configuration. By default, if none of ``body_close_issue_full_url``
+            and ``body_close_issue_on_last_line`` are enabled, this checks for
+            presence of short references like ``closes #213``.
+            Otherwise behaves according to other chosen flags.
             More on keywords follows.
             [GitHub](https://help.github.com/articles/closing-issues-via-commit-messages/)
             [GitLab](https://docs.gitlab.com/ce/user/project/issues/automatic_issue_closing.html)
@@ -282,6 +282,9 @@ class GitCommitBear(GlobalBear):
             When enabled, checks for issue close reference presence on the
             last line of the commit body. Works along with
             ``body_close_issue``.
+        :param body_enforce_issue_reference:
+            Whether to enforce presence of issue reference in the body of
+            commit message.
         """
         if not body_close_issue:
             return
@@ -326,7 +329,7 @@ class GitCommitBear(GlobalBear):
 
         matches = compiled_joint_regex.findall(body)
 
-        if len(matches) == 0:
+        if body_enforce_issue_reference and len(matches) == 0:
             yield Result(self, result_message.format(result_info))
             return
 

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -269,24 +269,23 @@ class GitCommitBearTest(unittest.TestCase):
                          [])
         self.assertTrue(self.msg_queue.empty())
 
-        # Testing body_regex
+        # body_regex, not fully matched
         self.git_commit('Shortlog\n\n'
                         'First line, blablablablablabla.\n'
                         'Another line, blablablablablabla.\n'
                         'Fix 1112')
         self.assertEqual(self.run_uut(
-                             body_regex=r'Fix\s+[1-9][0-9]*\s*'), [])
+                             body_regex=r'Fix\s+[1-9][0-9]*\s*'),
+                         ['No match found in commit message for the regular '
+                          'expression provided: Fix\s+[1-9][0-9]*\s*'])
         self.assert_no_msgs()
 
-        # Matching with regexp, no match found
+        # Matching with regexp, fully matched
         self.git_commit('Shortlog\n\n'
-                        'First line, blablablablablabla.\n'
-                        'Another line, blablablablablabla.\n'
-                        'Closes #01112')
+                        'TICKER\n'
+                        'CLOSE 2017')
         self.assertEqual(self.run_uut(
-                             body_regex=r'Closes\s+#[1-9][0-9]*\s*'),
-                         ['No match found in commit message for the regular '
-                          'expression provided: Closes\s+#[1-9][0-9]*\s*'])
+                             body_regex=r'TICKER\s*CLOSE\s+[1-9][0-9]*'), [])
         self.assert_no_msgs()
 
     def test_check_issue_reference(self):

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -328,9 +328,10 @@ class GitCommitBearTest(unittest.TestCase):
                         'This line is ok.\n'
                         'This line is by far too long (in this case).\n'
                         'This one too, blablablablablablablablabla.')
-        self.assertEqual(self.run_uut(body_close_issue=True,),
-                         ['Body of HEAD commit does not contain any issue '
-                          'reference.'])
+        self.assertEqual(self.run_uut(
+                             body_close_issue=True,
+                             body_close_issue_full_url=True,
+                             body_close_issue_last_line=True), [])
         self.assert_no_msgs()
 
         # Has keyword but no valid issue URL
@@ -456,7 +457,8 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_close_issue_full_url=True,
-                             body_close_issue_on_last_line=True),
+                             body_close_issue_on_last_line=True,
+                             body_enforce_issue_reference=True),
                          ['Body of HEAD commit does not contain any full issue'
                           ' reference in the last line.'])
         self.assert_no_msgs()

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -431,6 +431,23 @@ class GitCommitBearTest(unittest.TestCase):
                          ['Invalid issue number: #notnum'])
         self.assert_no_msgs()
 
+        # Close issues in other repos
+        self.git_commit('Shortlog\n\n'
+                        'First line, blablablablablabla.\n'
+                        'Another line, blablablablablabla.\n'
+                        'Resolve #11 and close github/gitter#32')
+        self.assertEqual(self.run_uut(body_close_issue=True,), [])
+        self.assert_no_msgs()
+
+        # Incorrect close issue other repo pattern
+        self.git_commit('Shortlog\n\n'
+                        'First line, blablablablablabla.\n'
+                        'Another line, blablablablablabla.\n'
+                        'Fix #11 and close github#32')
+        self.assertEqual(self.run_uut(body_close_issue=True,),
+                         ['Invalid issue reference: github#32'])
+        self.assert_no_msgs()
+
         # Last line enforce full URL
         self.git_commit('Shortlog\n\n'
                         'First line, blablablablablabla.\n'


### PR DESCRIPTION
Force body to follow a certain multiline pattern

Fixes #1331