### PR TITLE
FormatRBear.py: disable parameter-options

### DIFF
--- a/bears/r/FormatRBear.py
+++ b/bears/r/FormatRBear.py
@@ -33,8 +33,8 @@ class FormatRBear:
     def create_arguments(filename, file, config_file,
                          r_keep_comments: bool=True,
                          r_keep_blank_lines: bool=True,
-                         r_braces_on_next_line: bool=False,
-                         r_use_arrows: bool=False,
+                         r_braces_on_next_line: bool=None,
+                         r_use_arrows: bool=None,
                          indent_size:
                          int=SpacingHelper.DEFAULT_TAB_WIDTH,
                          r_max_expression_length: int=0):
@@ -79,12 +79,15 @@ class FormatRBear:
         """
         options = {'source="' + escape(filename, '"\\') + '"',
                    'blank=' + _map_to_r_bool(r_keep_blank_lines),
-                   'brace.newline=' + _map_to_r_bool(r_braces_on_next_line),
                    'comment=' + _map_to_r_bool(r_keep_comments),
-                   'arrow=' + _map_to_r_bool(r_use_arrows),
                    'indent=' + str(indent_size)}
         if r_max_expression_length:
             options.add('width.cutoff=' + str(r_max_expression_length))
+        if r_braces_on_next_line is not None:
+            options.add('brace.newline=' +
+                        _map_to_r_bool(r_braces_on_next_line))
+        if r_use_arrows is not None:
+            options.add('arrow=' + _map_to_r_bool(r_use_arrows))
 
         rcode = 'library(formatR);formatR::tidy_source({})'.format(
             ','.join(options))

--- a/tests/r/FormatRBearTest.py
+++ b/tests/r/FormatRBearTest.py
@@ -58,6 +58,14 @@ if (TRUE) {
 }
 """
 
+good_file_7 = """1 + 1
+if (TRUE) {
+    x = 1  # inline comments
+} else {
+    x <- 2
+    print("Oh no... ask the right bracket to go away!")
+}
+"""
 
 bad_file_1 = """1+1
 if(TRUE){
@@ -129,3 +137,9 @@ FormatRBearRWidthcutoffTest = verify_local_bear(
     valid_files=(good_file_6,),
     invalid_files=(bad_file_3,),
     settings={'r_max_expression_length': '25'})
+
+FormatRBearDefaultSettingsTest = verify_local_bear(
+    FormatRBear,
+    valid_files=(good_file_7,),
+    invalid_files=(bad_file_3,),
+    settings={})


### PR DESCRIPTION
r_keep_comments,r_keep_blank_lines,r_braces_on_next_line,r_use_arrows are
disabled and will not be checked untill the user provides value.

closes https://github.com/coala/coala-bears/issues/514