### PR TITLE
deps.sh: Reduce the length of output

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -1,5 +1,6 @@
 set -e
 set -x
+TERM=dumb
 
 # Choose the python versions to install deps for
 case $CIRCLE_NODE_INDEX in


### PR DESCRIPTION
Reduce the length of output in ci
log by removing download progress
information

Closes https://github.com/coala/coala-bears/issues/1123