### PR TITLE
PycodestyleBear.py: Add ignore E303

### DIFF
--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -36,6 +36,8 @@ class PycodestyleBear:
             Limit lines to this length.
         """
         arguments = [r"--format='%(row)d %(col)d %(code)s %(text)s'"]
+        # Ignore E303 as it is already covered by PEP8Bear.
+        arguments.append('--ignore=E303')
 
         if pycodestyle_ignore:
             arguments.append('--ignore=' + pycodestyle_ignore)

--- a/tests/python/PycodestyleBearTest.py
+++ b/tests/python/PycodestyleBearTest.py
@@ -12,9 +12,8 @@ bad_file = '''
 import something
 
 
-
 def hello():
-    print("hello world")
+    print ("hello world")
 '''
 
 PycodestyleBearTest = verify_local_bear(
@@ -26,7 +25,7 @@ PycodestyleBearConfigIgnoreTest = verify_local_bear(
     PycodestyleBear,
     valid_files=(good_file, bad_file),
     invalid_files=[],
-    settings={'pycodestyle_ignore': 'E303'})
+    settings={'pycodestyle_ignore': 'E211'})
 
 PycodestyleBearConfigSelectTest = verify_local_bear(
     PycodestyleBear,


### PR DESCRIPTION
Turn off E303 as it is already covered
by PEP8Bear.

Closes https://github.com/coala/coala/issues/3556