### PR TITLE
InvalidLinkBear: Support markdown files

### DIFF
--- a/bears/general/InvalidLinkBear.py
+++ b/bears/general/InvalidLinkBear.py
@@ -62,12 +62,12 @@ class InvalidLinkBear(LocalBear):
             [^.:%\s_/?#[\]@\\]+         # Initial part of domain
             \.                          # A required dot `.`
             (
-                (?:[^\s()%\'"`<>|\\]+)  # Path name
-                                        # This part does not allow
-                                        # any parenthesis: balanced or
-                                        # unbalanced.
-            |                           # OR
-                \([^\s()%\'"`<>|\\]*\)  # Path name contained within ()
+                (?:[^\s()%\'"`<>|\\\[\]]+)  # Path name
+                                            # This part does not allow
+                                            # any parenthesis: balanced or
+                                            # unbalanced.
+            |                               # OR
+                \([^\s()%\'"`<>|\\\[\]]*\)  # Path name contained within ()
                                         # This part allows path names that
                                         # are explicitly enclosed within one
                                         # set of parenthesis.

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -97,6 +97,7 @@ class InvalidLinkBearTest(unittest.TestCase):
         <http://httpbin.org/status/202>
         http://httpbin.org/status/204.....
         [httpbin](http://httpbin.org/status/200)
+        [http://httpbin.org/status/200](http://httpbin.org/status/200)
         |http://httpbin.org/status/200|
         <h3>Something http://httpbin.org/status/200</h3>
         repo=\\"http://httpbin.org/status/200\\"


### PR DESCRIPTION
Resolve matching for url of type ```[valid_url](valid_url)```

Fixes https://github.com/coala/coala-bears/issues/1338