### PR TITLE
bear-requirements.txt: Omit inherited dependencies

### DIFF
--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -23,7 +23,6 @@ pylint~=1.6
 pyroma~=2.2.0
 pyyaml~=3.12
 radon==1.4.0
-requests~=2.12
 restructuredtext-lint~=0.17.2
 rstcheck~=2.2
 safety~=0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
+# NOTE: This file is parsed by .ci/generate_bear_requirements.py
 # Use >= for development versions so that source builds always work
 coala>=0.10.0.dev20170113094654
 # Dependencies inherited from coala
 # libclang-py3
 # coala_utils
 # dependency_management
+# requests
 -r bear-requirements.txt


### PR DESCRIPTION
List inherited packages in requirements.txt, and
update generate_bear_requirements to not repeat
those packages in bear-requirements.

Use this to avoid adding requests to bear requirements.txt
Also fix requirement in InvalidLinkBear to match
requests version used by coala.