### PR TITLE
coafile: Rename 'body_close_issue_last_line to body_close_issue_on_last_line'.

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -33,7 +33,7 @@ shortlog_trailing_period = False
 shortlog_regex = ([^:]*|[^:]+: [A-Z0-9*].*)
 body_close_issue = True
 body_close_issue_full_url = True
-body_close_issue_last_line = True
+body_close_issue_on_last_line = True
 body_enforce_issue_reference = False
 
 [LineCounting]

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -331,7 +331,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_close_issue_full_url=True,
-                             body_close_issue_last_line=True), [])
+                             body_close_issue_on_last_line=True), [])
         self.assert_no_msgs()
 
         # Has keyword but no valid issue URL


### PR DESCRIPTION
coafile: Rename body_close_issue_last_line

Renamed `body_close_issue_last_line` to `body_close_issue_on_last_line`

Fixes #1362 