### PR TITLE
requirements.txt: Fixed coala version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE: This file is parsed by .ci/generate_bear_requirements.py
 # Use >= for development versions so that source builds always work
-coala>=0.10.0.dev20170113094654
+coala>=0.10.0.dev20170127183105
 # Dependencies inherited from coala
 # libclang-py3
 # coala_utils


### PR DESCRIPTION
coala now has Maven Requirement and
is_installed() function for Distribution
Requirement, So changed version to
0.10.0.dev20170127183105

Closes https://github.com/coala/coala-bears/issues/1251