### PR TITLE
WIP Appveyor: Problem with dependencies

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -47,9 +47,10 @@ install:
   - ECHO "Cached wheels:"
   - ps: "ls \"C:\\wheels\""
   - "%CMD_IN_ENV% pip wheel --use-wheel --wheel-dir C:\\wheels --find-links C:\\wheels -r test-requirements.txt"
-  - "%CMD_IN_ENV% pip wheel --use-wheel --wheel-dir C:\\wheels --find-links C:\\wheels -r requirements.txt"
+  - "%CMD_IN_ENV% set STATICBUILD=true && pip wheel --use-wheel --wheel-dir C:\\wheels --find-links C:\\wheels -r requirements.txt"
   - "%CMD_IN_ENV% pip install --find-links=C:\\wheels -r test-requirements.txt"
-  - "%CMD_IN_ENV% pip install --find-links=C:\\wheels -r requirements.txt"
+  - "%CMD_IN_ENV% set STATICBUILD=true && pip install --find-links=C:\\wheels -r requirements.txt"
+  - "%CMD_IN_ENV% easy_install --wheel-dir C:\\wheels --find-links=C:\\wheels lxml-3.2.1.win32-py3.3.‌exe"
   - "CALL .ci/deps.nltk.cmd"
 
   - ps: "Install-Product node ''"  # Use latest node v5.x.x

--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -11,6 +11,7 @@ guess-language-spirit~=0.5.2
 html-linter~=0.3.0
 isort~=4.2
 language-check~=0.8
+lxml~=3.3.5
 munkres3~=1.0
 mypy-lang~=0.4.6
 nbformat~=4.1


### PR DESCRIPTION
XMLBear is skipped on Appveyor Windows builds.
This installs dependencies for lxml.

Fixes https://github.com/coala/coala-bears/issues/1354