### PR TITLE
.ci/deps.sh: Use cached ghc-mod

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -95,8 +95,10 @@ if [[ -z "$(which hlint)" ]]; then
 fi
 
 # cabal update to 1.22.9.0 and install ghc-mod 5.6.0
-cabal update && cabal install cabal-install-1.22.9.0
-cabal install ghc-mod
+if [[ -z "$(which ghc-mod)" ]]; then
+  cabal update && cabal install cabal-install-1.22.9.0
+  cabal install ghc-mod
+fi
 
 # NPM commands
 sudo rm -rf $(which alex)  # Delete ghc-alex as it clashes with npm deps


### PR DESCRIPTION
Do not re-install ghc-mod from source
if it has already been cached.

Related to https://github.com/coala/coala-bears/issues/297