### PR TITLE
ShellCheckBear: Add option to ignore specific rules

### DIFF
--- a/bears/shell/ShellCheckBear.py
+++ b/bears/shell/ShellCheckBear.py
@@ -20,8 +20,14 @@ class ShellCheckBear:
     CAN_DETECT = {'Syntax', 'Security', 'Undefined Element', 'Unused Code'}
 
     @staticmethod
-    def create_arguments(filename, file, config_file, shell: str='sh'):
+    def create_arguments(filename, file, config_file, shell: str='sh',
+                         shellcheck_ignore: list=None):
         """
         :param shell: Target shell being used.
+        :param shellcheck_ignore: List of linting rules that should be ignored.
         """
-        return '--f', 'gcc', '-s', shell, filename
+        args = ('--f', 'gcc', '-s', shell, filename)
+        if shellcheck_ignore:
+            args += ('-e', ','.join(shellcheck_ignore))
+
+        return args

--- a/tests/shell/ShellCheckBearTest.py
+++ b/tests/shell/ShellCheckBearTest.py
@@ -17,7 +17,55 @@ X+=2    # += operator is supported by bash and not by sh
 echo $X
 """
 
+trigger_sc2164 = """
+#!/usr/bin/env sh
+for dir in */
+do
+  cd "$dir"
+  convert index.png index.jpg
+done
+"""
 
+trigger_sc2060 = """
+#!/usr/bin/env sh
+tr -cd [:digit:]
+"""
+
+good_zero_byte = ''
+good_only_eol = '\n'
+good_only_eol_eol = '\n\n'
+good_only_comment = '# this is a bash comment'
+
+invalid_file_list = (invalid_file, trigger_sc2164, trigger_sc2060,)
 ShellCheckBearTest = verify_local_bear(ShellCheckBear,
                                        valid_files=(valid_file,),
-                                       invalid_files=(invalid_file,))
+                                       invalid_files=invalid_file_list,
+                                       )
+
+small_files = (good_zero_byte, good_only_eol, good_only_eol_eol,
+               good_only_comment,)
+SmallFileTest = verify_local_bear(ShellCheckBear,
+                                  valid_files=small_files,
+                                  invalid_files=(),
+                                  )
+
+IgnoreSC2164Test = verify_local_bear(ShellCheckBear,
+                                     valid_files=(trigger_sc2164,),
+                                     invalid_files=(),
+                                     settings={
+                                         'shellcheck_ignore': ['SC2164']},
+                                     )
+IgnoreSC2060Test = verify_local_bear(ShellCheckBear,
+                                     valid_files=(trigger_sc2060,),
+                                     invalid_files=(),
+                                     settings={
+                                         'shellcheck_ignore': ['SC2060']},
+                                     )
+MultipleIgnoreTest = verify_local_bear(ShellCheckBear,
+                                       valid_files=(trigger_sc2164,
+                                                    trigger_sc2060,),
+                                       invalid_files=(),
+                                       settings={
+                                           'shellcheck_ignore': ['SC2164',
+                                                                 'SC2060']},
+                                       )


### PR DESCRIPTION
This extend the ShellCheckBear to use **ignore rules** feature provided by shellcheck, see
https://github.com/koalaman/shellcheck/wiki/Ignore#ignoring-errors-in-one-specific-run

The commandline argument for ignoring rules is `-e SCXXX1,SCXXX2,SCXXX3`

Closes https://github.com/coala/coala-bears/issues/1329