### PR TITLE
PycodestyleBear.py: Remove extra "'" from message

### DIFF
--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -35,7 +35,7 @@ class PycodestyleBear:
         :param max_line_length:
             Limit lines to this length.
         """
-        arguments = [r"--format='%(row)d %(col)d %(code)s %(text)s'"]
+        arguments = [r'--format=%(row)d %(col)d %(code)s %(text)s']
 
         if pycodestyle_ignore:
             arguments.append('--ignore=' + pycodestyle_ignore)


### PR DESCRIPTION
Fixes https://github.com/coala/coala-bears/issues/1393