### PR TITLE
.ci/deps.sh: Do not install go documentation

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -13,7 +13,7 @@ esac
 # apt-get commands
 export DEBIAN_FRONTEND=noninteractive
 
-deps="libclang1-3.4 indent mono-mcs chktex r-base julia golang luarocks verilator cppcheck flawfinder"
+deps="libclang1-3.4 indent mono-mcs chktex r-base julia golang-go luarocks verilator cppcheck flawfinder"
 deps_infer="m4 opam"
 
 case $CIRCLE_BUILD_IMAGE in
@@ -30,7 +30,7 @@ case $CIRCLE_BUILD_IMAGE in
     sudo chmod a+x /usr/bin/systemd-detect-virt
 
     # The non-apt go provided by Circle CI is acceptable
-    deps=${deps/golang/}
+    deps=${deps/golang-go/}
     # Add packages which are available in xenial
     # The xenial hlint is >= 1.9.1
     deps="$deps hlint"


### PR DESCRIPTION
Installing apt package 'golang' installs 'golang-doc',
for documentation, which is not needed.
Installing the golang-go package also installs 'golang-src'
but omits golang-doc.

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
