### PR TITLE
PyDocStyleBear.py: Add new parameters

### DIFF
--- a/bears/python/PyDocStyleBear.py
+++ b/bears/python/PyDocStyleBear.py
@@ -21,14 +21,23 @@ class PyDocStyleBear:
 
     def create_arguments(self, filename, file, config_file,
                          pydocstyle_select: typed_list(str)=(),
-                         pydocstyle_ignore: typed_list(str)=()):
+                         pydocstyle_ignore: typed_list(str)=(),
+                         pydocstyle_add_ignore: typed_list(str)=(),
+                         pydocstyle_add_select: typed_list(str)=()):
         """
         :param pydocstyle_select:
             List of checked errors by specifying which errors to check for.
             Can't be used together with ``pydocstyle_ignore``.
         :param pydocstyle_ignore:
             List of checked errors by specifying which errors to ignore. Can't
-            be used together with ``pydocstyle_select``.
+            be used together with ``pydocstyle_select``. It overrides
+            default list of to-ignore error list.
+        :param pydocstyle_add_ignore:
+            List of checked errors to amend the list of default errors to
+            check for by specifying more error codes to ignore.
+        :param pydocstyle_add_select:
+            List of checked errors to amend the list of default errors to
+            check for by specifying more error codes to check.
         """
         args = (filename,)
         if pydocstyle_ignore and pydocstyle_select:
@@ -41,5 +50,13 @@ class PyDocStyleBear:
         elif pydocstyle_select:
             select = ','.join(part.strip() for part in pydocstyle_select)
             args += ('--select=' + select,)
+        elif pydocstyle_add_ignore:
+            add_ignore = ','.join(part.strip()
+                                  for part in pydocstyle_add_ignore)
+            args += ('--add-ignore=' + add_ignore,)
+        elif pydocstyle_add_select:
+            add_select = ','.join(part.strip()
+                                  for part in pydocstyle_add_select)
+            args += ('--add-select=' + add_select,)
 
         return args

--- a/tests/python/PyDocStyleBearTest.py
+++ b/tests/python/PyDocStyleBearTest.py
@@ -44,6 +44,14 @@ PyDocStyleBearIgnoreSomeTest = verify_local_bear(
     settings={'pydocstyle_ignore': 'D400, D200'},
     tempfile_kwargs={'suffix': '.py'})
 
+# Checks the functionality of add-ignore
+PyDocStyleBearAddIgnoreTest = verify_local_bear(
+    PyDocStyleBear,
+    valid_files=(good_file, bad_file,),
+    invalid_files=(),
+    settings={'pydocstyle_add_ignore': 'D400, D200, D103'},
+    tempfile_kwargs={'suffix': '.py'})
+
 # Checks if an invalid file yields results when a particular error is selected.
 PyDocStyleBearSelectSomeTest = verify_local_bear(
     PyDocStyleBear,
@@ -59,6 +67,14 @@ PyDocStyleBearSelectAbsentErrorTest = verify_local_bear(
     valid_files=(good_file, bad_file,),
     invalid_files=(),
     settings={'pydocstyle_select': 'D500'},
+    tempfile_kwargs={'suffix': '.py'})
+
+# Checks the functionality of add-select
+PyDocStyleBearAddSelectTest = verify_local_bear(
+    PyDocStyleBear,
+    valid_files=(good_file,),
+    invalid_files=(bad_file,),
+    settings={'pydocstyle_add_select': 'D212'},
     tempfile_kwargs={'suffix': '.py'})
 
 PyDocStyleBearSelectAndIgnoreTest = verify_local_bear(


### PR DESCRIPTION
It adds two new parameters for the bear
`pydocstyle_add_ignore` and `pydocstyle
_add_select`. It also improves the param
definition of `ignore`. Earlier,
conflicting checks were getting enabled
due to misuse of `ignore`.

Fixes https://github.com/coala/coala-bears/issues/1345

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
