### PR TITLE
JSONFormatBear: Parse Exception message

### DIFF
--- a/bears/js/JSONFormatBear.py
+++ b/bears/js/JSONFormatBear.py
@@ -1,5 +1,6 @@
 import json
 from collections import OrderedDict
+from re import match
 
 from coala_utils.param_conversion import negate
 from coalib.bearlib import deprecate_settings
@@ -37,10 +38,14 @@ class JSONFormatBear(LocalBear):
             json_content = json.loads(''.join(file),
                                       object_pairs_hook=OrderedDict)
         except JSONDecodeError as err:
+            err_content = match(r'(.*): line (\d+) column (\d+)', str(err))
             yield Result.from_values(
                 self,
-                'This file does not contain parsable JSON. ' + repr(str(err)),
-                file=filename)
+                'This file does not contain parsable JSON. ' +
+                err_content.group(1) + '.',
+                file=filename,
+                line=int(err_content.group(2)),
+                column=int(err_content.group(3)))
             return
 
         corrected = json.dumps(json_content,

--- a/bears/js/JSONFormatBear.py
+++ b/bears/js/JSONFormatBear.py
@@ -34,6 +34,13 @@ class JSONFormatBear(LocalBear):
         :param escape_unicode: Whether or not to escape unicode values using
                                ASCII.
         """
+        # Output a meaningful message if empty file given as input
+        if len(file) == 0:
+            yield Result.from_values(self,
+                                     'This file is empty.',
+                                     file=filename)
+            return
+
         try:
             json_content = json.loads(''.join(file),
                                       object_pairs_hook=OrderedDict)

--- a/tests/js/JSONFormatBearTest.py
+++ b/tests/js/JSONFormatBearTest.py
@@ -1,5 +1,10 @@
-from bears.js import JSONFormatBear
-from coalib.testing.LocalBearTestHelper import verify_local_bear
+from queue import Queue
+
+from bears.js.JSONFormatBear import JSONFormatBear
+from coalib.testing.LocalBearTestHelper import (verify_local_bear,
+                                                LocalBearTestHelper)
+from coalib.results.Result import Result
+from coalib.settings.Section import Section
 
 
 test_file1 = """{
@@ -25,7 +30,32 @@ unicode_file = """{
 }"""
 
 
-JSONFormatBearTest = verify_local_bear(JSONFormatBear.JSONFormatBear,
+test_file4 = """{
+    a: 5
+}"""
+
+
+class JSONTest(LocalBearTestHelper):
+
+    def setUp(self):
+        self.section = Section('')
+        self.uut = JSONFormatBear(self.section, Queue())
+
+    def test_exception_result(self):
+        self.check_results(
+            self.uut,
+            test_file4.split('\n'),
+            [Result.from_values('JSONFormatBear',
+                                'This file does not contain parsable JSON. '
+                                'Expecting property name enclosed in '
+                                'double quotes.',
+                                file='default',
+                                line=2,
+                                column=5)],
+            filename='default')
+
+
+JSONFormatBearTest = verify_local_bear(JSONFormatBear,
                                        valid_files=(test_file1, test_file2),
                                        invalid_files=(test_file3,
                                                       unicode_file,
@@ -34,20 +64,20 @@ JSONFormatBearTest = verify_local_bear(JSONFormatBear.JSONFormatBear,
                                                       '{"a":5,"b":5}'))
 
 
-JSONFormatBearSortTest = verify_local_bear(JSONFormatBear.JSONFormatBear,
+JSONFormatBearSortTest = verify_local_bear(JSONFormatBear,
                                            valid_files=(test_file1,),
                                            invalid_files=(test_file2,),
                                            settings={'json_sort': 'true'})
 
 
-JSONFormatBearTabWidthTest = verify_local_bear(JSONFormatBear.JSONFormatBear,
+JSONFormatBearTabWidthTest = verify_local_bear(JSONFormatBear,
                                                valid_files=(test_file3,),
                                                invalid_files=(test_file2,),
                                                settings={
                                                    'indent_size': '3'})
 
 
-JSONFormatBearUnicodeTest = verify_local_bear(JSONFormatBear.JSONFormatBear,
+JSONFormatBearUnicodeTest = verify_local_bear(JSONFormatBear,
                                               valid_files=(unicode_file,),
                                               invalid_files=(),
                                               settings={'escape_unicode':

--- a/tests/js/JSONFormatBearTest.py
+++ b/tests/js/JSONFormatBearTest.py
@@ -54,6 +54,15 @@ class JSONTest(LocalBearTestHelper):
                                 column=5)],
             filename='default')
 
+    def test_exception_empty_file(self):
+        self.check_results(
+            self.uut,
+            [],
+            [Result.from_values('JSONFormatBear',
+                                'This file is empty.',
+                                file='default')],
+            filename='default')
+
 
 JSONFormatBearTest = verify_local_bear(JSONFormatBear,
                                        valid_files=(test_file1, test_file2),


### PR DESCRIPTION
This change parses the default exception message to print
only 'Expecting property name enclosed in double quotes.'
instead of 'Expecting property name enclosed in double
quotes: line 2 column 7 (char 8)'.It also shows line and
column where the error is raised.

Closes https://github.com/coala/coala-bears/issues/35

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
