### PR TITLE
yamllint: Disable `document-start` by default

### DIFF
--- a/bears/yaml/YAMLLintBear.py
+++ b/bears/yaml/YAMLLintBear.py
@@ -24,7 +24,7 @@ class YAMLLintBear:
 
     @staticmethod
     def generate_config(filename, file,
-                        document_start: bool=False):
+                        document_start: bool=None):
         """
         :param document_start:
             Use this rule to require or forbid the use of document start
@@ -33,13 +33,10 @@ class YAMLLintBear:
         yamllint_configs = {
             'extends': 'default',
             'rules': {
-                'document-start': {
-                    'present': False
-                 }
-            }
+                'document-start': 'disable' if document_start is None
+                                  else {'present': document_start},
+            },
         }
-        if document_start:
-            yamllint_configs['rules']['document-start']['present'] = True
 
         return yaml.dump(yamllint_configs)
 

--- a/tests/yaml/YAMLLintBearTest.py
+++ b/tests/yaml/YAMLLintBearTest.py
@@ -70,11 +70,16 @@ with prepare_file(config_file,
                                               'yamllint_config': conf_file})
 
 YAMLLintBear3Test = verify_local_bear(YAMLLintBear,
-                                      valid_files=(no_start_yaml_file,),
-                                      invalid_files=(with_start_yaml_file,))
+                                      valid_files=(no_start_yaml_file,
+                                                   with_start_yaml_file,),
+                                      invalid_files=())
 
 YAMLLintBear4Test = verify_local_bear(YAMLLintBear,
+                                      valid_files=(no_start_yaml_file,),
+                                      invalid_files=(with_start_yaml_file,),
+                                      settings={'document_start': False})
+
+YAMLLintBear5Test = verify_local_bear(YAMLLintBear,
                                       valid_files=(with_start_yaml_file,),
                                       invalid_files=(no_start_yaml_file,),
-                                      settings={
-                                          'document_start': True})
+                                      settings={'document_start': True})


### PR DESCRIPTION
Some projects use documents starts (`---`) in YAML documents (for example Ansible, OpenStack, yamllint), others don't. Since these markers are required when declaring multiple documents in a single .yaml file (see [the spec](http://yaml.org/spec/1.2/spec.html#id2800132)), it is a bad idea to forbid them.

This commit disables the `document-start` rule by default, instead of forcing / forbidding the use of these markers.

Closes: #1417
Fixes: #923 #965