### PR TITLE
GitCommitBear.py: Restrict number of newlines

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -90,7 +90,7 @@ class GitCommitBear(GlobalBear):
         Check the current git commit message at HEAD.
 
         This bear ensures automatically that the shortlog and body do not
-        exceed a given line-length and that a newline lies between them.
+        exceed a given line-length and that one newline lies between them.
 
         :param allow_empty_commit_message: Whether empty commit messages are
                                            allowed or not.
@@ -104,8 +104,19 @@ class GitCommitBear(GlobalBear):
 
         stdout = stdout.rstrip('\n')
         pos = stdout.find('\n')
+        count = 0
         shortlog = stdout[:pos] if pos != -1 else stdout
-        body = stdout[pos+1:] if pos != -1 else ''
+        pos = pos + 1
+
+        while (stdout[pos+1] == '\n'):
+            count++
+
+        if count == 0:
+            body = stdout[pos+1:] if pos != -1 else ''
+        else
+            yield Result(self,
+                         'There are too many newlines between shortlog '
+                         'and body.')
 
         if len(stdout) == 0:
             if not allow_empty_commit_message:


### PR DESCRIPTION
This ensures that the shortlog and body and seperated by at most
ont newline.

Closes https://github.com/coala/coala-bears/issues/1351

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
