### PR TITLE
.travis.yml: Use Python version '3.6'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
-  - 3.6-dev
+  - 3.6
 
 dist: trusty
 
@@ -76,8 +76,6 @@ before_install:
       UNSUPPORTED=true
     fi
 
-  - nvm install 4
-  - nvm use 4
   # Remove Ruby directive from Gemfile as this image has 2.2.5
   - sed -i '/^ruby/d' Gemfile
   - if [[ "$UNSUPPORTED" != true ]]; then bash .ci/deps.sh; fi


### PR DESCRIPTION
Python version `3.6-dev` is confusing, as Python 3.6 has been
officially released.

Also remove unnecessary nvm commands.