### PR TITLE
MarkdownBear: Restrict remark-lint to ~5

### DIFF
--- a/bears/markdown/MarkdownBear.py
+++ b/bears/markdown/MarkdownBear.py
@@ -21,7 +21,7 @@ class MarkdownBear:
 
     LANGUAGES = {'Markdown'}
     REQUIREMENTS = {NpmRequirement('remark-cli', '2'),
-                    NpmRequirement('remark-lint', '>=5.1.0')}
+                    NpmRequirement('remark-lint', '5')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postcss-cli": "~2",
     "ramllint": "~1.2.2",
     "remark-cli": "~2",
-    "remark-lint": ">=5.1.0",
+    "remark-lint": "~5",
     "tslint": "~3",
     "typescript": ">=1.7.3",
     "write-good": "~0.9.1"


### PR DESCRIPTION
Use remark-lint 5.4 if available.

Fixes https://github.com/coala/coala-bears/issues/1444
(cherry-picked from f3411d16)