### PR TITLE
MANIFEST.in: Add bear-requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include LICENSE
-include test-requirements.txt
 include requirements.txt
+include bear-requirements.txt
+include test-requirements.txt
 include setup.cfg


### PR DESCRIPTION
bear-requirements.txt is used by setup.py and
requirements.txt

Fixes https://github.com/coala/coala-bears/issues/1448
