### PR TITLE
GitCommitBear.py: Restrict no. of newlines

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -106,6 +106,10 @@ class GitCommitBear(GlobalBear):
         pos = stdout.find('\n')
         shortlog = stdout[:pos] if pos != -1 else stdout
         body = stdout[pos+1:] if pos != -1 else ''
+        if pos != -1:
+            if stdout[pos+2] == '\n':
+                yield Result(self, 'Extra Newlines found.')
+                return
 
         if len(stdout) == 0:
             if not allow_empty_commit_message:

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -37,7 +37,6 @@ class GitCommitBearTest(unittest.TestCase):
         """
         Runs the unit-under-test (via `self.uut.run()`) and collects the
         messages of the yielded results as a list.
-
         :param args:   Positional arguments to forward to the run function.
         :param kwargs: Keyword arguments to forward to the run function.
         :return:       A list of the message strings.
@@ -113,6 +112,15 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(git_error[:4], 'git:')
 
         self.assert_no_msgs()
+
+    def test_extra_newlines_between_shortlog_body(self):
+        self.git_commit(
+            'Extra newlines\n\n\n'
+            'between shortlog and body'
+            'blablabla.')
+
+        self.assertEqual(self.run_uut(),
+                         ['Extra Newlines found.'])
 
     def test_empty_message(self):
         self.git_commit('')


### PR DESCRIPTION
Add a condition to throw warnings if no. of
newlines between shortlog and body exceed 1.

Closes https://github.com/coala/coala-bears/issues/1351

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
