### PR TITLE
CI: Fetch coala-bears dependency files

### DIFF
--- a/.ci/deps.coala-bears.sh
+++ b/.ci/deps.coala-bears.sh
@@ -1,0 +1,9 @@
+set -x
+set -e
+
+# making coala cache the dependencies downloaded upon first run
+echo '' > /tmp/dummy
+
+coala --ci -V --bears CheckstyleBear,ScalaLintBear --files /tmp/dummy --no-config --bear-dirs bears
+
+rm /tmp/dummy

--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -170,8 +170,3 @@ if [ ! -e ~/.local/tailor/tailor-latest ]; then
   # Provide a constant path for the executable
   ln -s ~/.local/tailor/tailor-* ~/.local/tailor/tailor-latest
 fi
-
-# making coala cache the dependencies downloaded upon first run
-echo '' > dummy
-coala-ci --bears CheckstyleBear --files dummy --no-config --bear-dirs bears || true
-coala-ci --bears ScalaLintBear --files dummy --no-config --bear-dirs bears || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,6 +94,7 @@ before_install:
 
 before_script:
   - mv requirements.orig requirements.txt
+  - if [[ "$UNSUPPORTED" != true ]]; then bash .ci/deps.coala-bears.sh; fi
   # nltk 3.2.2 dropped support for Python 3.3
   - >
     if [[ "$TRAVIS_PYTHON_VERSION" != "3.3" ]]; then

--- a/circle.yml
+++ b/circle.yml
@@ -36,6 +36,7 @@ dependencies:
     - bash .ci/deps.cabal.sh
     - bash .ci/deps.sh:
         timeout: 900  # Allow 15 mins before timing out due to "no output"
+    - bash .ci/deps.coala-bears.sh
 
 machine:
   java:


### PR DESCRIPTION
Download checkstyle and scalastyle jar files before running tests on Travis and AppVeyor.