### PR TITLE
AppVeyor CI: Allow builds on forks

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -20,10 +20,9 @@ cache:
   - "C:\\Users\\appveyor\\AppData\\Local\\coala-bears\\coala-bears"
   - "C:\\Users\\appveyor\\AppData\\Roaming\\nltk_data"
 
-branches:  # Only build official branches, PRs are built anyway.
-  only:
-    - master
-    - /release.*/
+branches:
+  except:
+    - /^sils\/.*/
 
 install:
   # Prepend newly installed Python to the PATH of this build (this cannot be


### PR DESCRIPTION
Exclude only branch 'sils/*'.

Closes https://github.com/coala/coala-bears/issues/1285
Related to https://github.com/coala/coala/issues/3664
