### PR TITLE
CheckstyleBear: Remove geosoft ruleset

### DIFF
--- a/bears/java/CheckstyleBear.py
+++ b/bears/java/CheckstyleBear.py
@@ -11,7 +11,7 @@ _online_styles = {
     'android-check-hard': 'https://raw.githubusercontent.com/noveogroup/' +
     'android-check/master/android-check-plugin/src/main/resources/' +
     'checkstyle/checkstyle-hard.xml',
-    'geosoft': 'http://geosoft.no/development/geosoft_checks.xml'}
+}
 
 # To be deprecated
 known_checkstyles = dict(_online_styles, **{'google': None, 'sun': None})

--- a/tests/java/CheckstyleBearTest.py
+++ b/tests/java/CheckstyleBearTest.py
@@ -43,10 +43,6 @@ class CheckstyleBearTest(LocalBearTestHelper):
         self.section['checkstyle_configs'] = 'android-check-hard'
         self.check_validity(self.uut, [], self.good_file)
 
-    def test_style_geosoft(self):
-        self.section['checkstyle_configs'] = 'geosoft'
-        self.check_validity(self.uut, [], self.good_file)
-
     def test_config_failure_use_spaces(self):
         self.section['checkstyle_configs'] = 'google'
         self.section.append(Setting('use_spaces', False))


### PR DESCRIPTION
The geosoft ruleset last worked with checkstyle 4.4.

Fixes https://github.com/coala/coala-bears/issues/1463