### PR TITLE
coala-bears.cabal: Pin cmdargs==0.10.14

### DIFF
--- a/coala-bears.cabal
+++ b/coala-bears.cabal
@@ -10,4 +10,4 @@ build-type: Simple
 -- which is incompatible with ShellCheck 0.4.1 which needs mtl-2.2.1
 
 library
-  build-depends: base, Cabal>=1.16, safe==0.3.9, ghc-mod==5.6.0.0, hlint==1.9.27, ShellCheck==0.4.1
+  build-depends: base, Cabal>=1.16, safe==0.3.9, cmdargs==0.10.14, ghc-mod==5.6.0.0, hlint==1.9.27, ShellCheck==0.4.1


### PR DESCRIPTION
cmdargs==0.10.15 requires Cabal 1.18, which is not
available on all CI workers.

Fixes https://github.com/coala/coala-bears/issues/1508