### PR TITLE
PyImportSortBear.py: Add missing parameter

### DIFF
--- a/bears/python/PyImportSortBear.py
+++ b/bears/python/PyImportSortBear.py
@@ -169,6 +169,7 @@ class PyImportSortBear(LocalBear):
             forced_separate=forced_separate_imports,
             multi_line_output=isort_multi_line_output,
             known_first_party=known_first_party_imports,
+            known_third_party=known_third_party_imports,
             line_length=max_line_length,
             force_to_top=imports_forced_to_top)
 

--- a/tests/python/PyImportSortBearTest.py
+++ b/tests/python/PyImportSortBearTest.py
@@ -21,3 +21,9 @@ PyImportSortBearIgnoredConfigsTest = verify_local_bear(
      'import abc\nimport xyz\n'),
     settings={'known_standard_library_imports': 'xyz',
               'known_first_party_imports': 'abc'})
+
+PyImportSortBearThirdPartyConfigTest = verify_local_bear(
+    PyImportSortBear,
+    ('import sys\n\nimport datetime\n',),
+    ('import datetime\nimport sys\n',),
+    settings={'known_third_party_imports': 'datetime'})


### PR DESCRIPTION
Added a missing parameter known_third_party to isort
function. It was being passed to run function but
was missing in wrapper.

Fixes https://github.com/coala/coala-bears/issues/1510