### PR TITLE
bears/__init__.py: Check version with coala core

### DIFF
--- a/bears/__init__.py
+++ b/bears/__init__.py
@@ -4,6 +4,8 @@ the bears that are officially supported by coala.
 """
 
 
+from distutils.version import StrictVersion
+import logging
 import os
 import sys
 
@@ -20,3 +22,27 @@ def assert_supported_version():  # pragma: no cover
     if sys.version_info < (3, 4):
         print('coala supports only python 3.4 or later.')
         exit(4)
+
+
+def check_coala_version():
+    """
+    Check the installed coala and coala-bears version.
+    """
+    try:
+        import coalib
+        # check only MAJOR.MINOR version
+        coalib_version = '.'.join(coalib.__version__.split('.')[:2])
+        bears_version = '.'.join(__version__.split('.')[:2])
+        if StrictVersion(coalib_version) > StrictVersion(bears_version):
+            logging.warning('Version mismatch between coala ({}) and '
+                            'coala-bears ({}). This may or may not cause '
+                            'errors. If you encounter a problem, try to '
+                            'update coala and coala-bears to latest version '
+                            "with 'pip3 install -U coala coala-bears'."
+                            .format(coalib.__version__, __version__))
+    except ImportError:  # pragma: no cover
+        logging.error('Module coalib is not found. Cannot do version '
+                      'checking.')
+
+
+check_coala_version()

--- a/tests/coalaBearTest.py
+++ b/tests/coalaBearTest.py
@@ -1,0 +1,25 @@
+import logging
+import unittest
+
+import bears
+import coalib
+
+
+class coalaBearTest(unittest.TestCase):
+
+    def test_check_coala_version(self):
+        bears.__version__ = coalib.__version__ = '1.0.0.dev999999999'
+        logger = logging.getLogger()
+        with self.assertLogs(logger, 'WARNING') as cm:
+            bears.check_coala_version()
+            self.assertEqual(0, len(cm.output))
+
+            bears.__version__ = '1.1.0.dev999999999'
+            bears.check_coala_version()
+            self.assertEqual(0, len(cm.output))
+
+            bears.__version__ = '1.0.0.dev999999999'
+            coalib.__version__ = '1.1.0.dev999999999'
+            bears.check_coala_version()
+            self.assertIn('Version mismatch between coala',
+                          cm.output[0])


### PR DESCRIPTION
Print a warning if the installed version of coala is not 
same with coala-bears.

Closes https://github.com/coala/coala/issues/3042