### PR TITLE
FilenameBear: Allow case-independent parameters

### DIFF
--- a/bears/general/FilenameBear.py
+++ b/bears/general/FilenameBear.py
@@ -39,7 +39,7 @@ class FilenameBear(LocalBear):
         head, tail = os.path.split(filename)
         filename_without_extension, extension = os.path.splitext(tail)
         try:
-            new_name = self._naming_convention[file_naming_convention](
+            new_name = self._naming_convention[file_naming_convention.lower()](
                 filename_without_extension)
         except KeyError:
             self.err('Invalid file-naming-convention provided: ' +

--- a/tests/general/FilenameBearTest.py
+++ b/tests/general/FilenameBearTest.py
@@ -68,3 +68,9 @@ class SpaceConsistencyBearTest(LocalBearTestHelper):
         self.section['ignore_uppercase_filenames'] = 'nope'
 
         self.check_validity(self.uut, [''], filename='/LICENSE', valid=False)
+
+    def test_upper_case(self):
+        self.section['file_naming_convention'] = 'Snake'
+        self.check_validity(self.uut, [''], filename='/Home/xyz/x_y.py')
+        self.check_validity(self.uut, [''], filename='XYZ/__init__.py')
+        self.check_validity(self.uut, [''], filename='/a/pyCase', valid=False)


### PR DESCRIPTION
FilenameBear: Allow case-independent parameters

Allow different cases for `file_naming_convention` parameter.

Closes https://github.com/coala/coala-bears/issues/1540
<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [X] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [X] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
