### PR TITLE
CheckstyleBear: Upgrade checkstyle to 6.19

### DIFF
--- a/bears/java/CheckstyleBear.py
+++ b/bears/java/CheckstyleBear.py
@@ -53,9 +53,9 @@ class CheckstyleBear:
 
     def setup_dependencies(self):
         type(self).checkstyle_jar_file = self.download_cached_file(
-            'https://github.com/coala/bear-runtime-deps/raw/master'
-            '/CheckstyleBear/checkstyle-6.15-all.jar',
-            'checkstyle-6.15-all.jar')
+            'http://sourceforge.net/projects/checkstyle/files/checkstyle/6.19'
+            '/checkstyle-6.19-all.jar',
+            'checkstyle-6.19.jar')
 
     def create_arguments(
             self, filename, file, config_file,


### PR DESCRIPTION
checkstyle 6.19 is the last release in the 6.x
series, fixing many bugs in 6.15 which coala
has been using.

Fixes https://github.com/coala/coala-bears/issues/1465
