### PR TITLE
pyroma_test_files: Remove unnecessary print

### DIFF
--- a/tests/python/pyroma_test_files/complete/complete/__init__.py
+++ b/tests/python/pyroma_test_files/complete/complete/__init__.py
@@ -1,3 +1,3 @@
 import os
 
-print(os.__doc__)
+os.__doc__


### PR DESCRIPTION
The print call in the pyroma_test_files complate package ``__init__``
is unnecessary for the test, and causes unexpected output when a test
runner such as ``green`` collects ``test_*.py`` by default.

Fixes https://github.com/coala/coala-bears/issues/1594