### PR TITLE
Add argument for include paths

### DIFF
--- a/bears/c_languages/CPPCheckBear.py
+++ b/bears/c_languages/CPPCheckBear.py
@@ -29,17 +29,24 @@ class CPPCheckBear:
 
     @staticmethod
     def create_arguments(filename, file, config_file,
-                         enable: typed_list(str)=[]):
+                         enable: typed_list(str)=[],
+                         include_paths: str=None):
         """
         :param enable:
             Choose specific issues to report. Issues that can be
             reported are: all, warning, style, performance,
             portability, information, unusedFunction,
             missingInclude
+        :param include_paths:
+            Specify include paths to make sure cppcheck
+            can find all the relevant code.
         """
         args = ('--template={line}:{severity}:{id}:{message}',)
 
         if enable:
             args += ('--enable=' + ','.join(enable),)
+
+        if include_paths:
+            args += include_paths,
 
         return args + (filename,)

--- a/tests/c_languages/CPPCheckBearTest.py
+++ b/tests/c_languages/CPPCheckBearTest.py
@@ -1,3 +1,4 @@
+import os
 from bears.c_languages.CPPCheckBear import CPPCheckBear
 from coalib.testing.LocalBearTestHelper import verify_local_bear
 
@@ -26,10 +27,12 @@ int main() {
     return 0;
 }"""
 
+test_dir = os.path.join(os.path.dirname(__file__), 'test_files')
 
 CPPCheckBearTest1 = verify_local_bear(CPPCheckBear,
                                       valid_files=(good_file, warn_file),
-                                      invalid_files=(bad_file,))
+                                      invalid_files=(bad_file,),
+                                      settings={'include_paths': test_dir})
 
 CPPCheckBearTest2 = verify_local_bear(CPPCheckBear,
                                       valid_files=(good_file,),


### PR DESCRIPTION
CPPCheck supports include paths on its argument processor and this is fundamental for using it in big projects.

Closes https://github.com/coala/coala-bears/issues/1701