### PR TITLE
Allow usage of custom rule set on JavaPMDBear

### DIFF
--- a/bears/java/JavaPMDBear.py
+++ b/bears/java/JavaPMDBear.py
@@ -37,6 +37,7 @@ class JavaPMDBear:
     @deprecate_settings(allow_unnecessary_code=('check_unnecessary', negate),
                         allow_unused_code=('check_unused', negate))
     def create_arguments(filename, file, config_file,
+                         pmd_config: str = None,
                          check_best_practices: bool = True,
                          check_braces: bool = True,
                          check_clone_implementation: bool = True,
@@ -50,6 +51,8 @@ class JavaPMDBear:
                          allow_unnecessary_code: bool = False,
                          allow_unused_code: bool = False):
         """
+        :param pmd_config:
+            Specify custom rule set file path. Overrides all other settings.
         :param check_best_practices:
             Checks for best practices.
         :param check_braces:
@@ -78,21 +81,24 @@ class JavaPMDBear:
         :param allow_unused_code:
             Allows unused code.
         """
-        options = {
-            'java-basic': check_best_practices,
-            'java-braces': check_braces,
-            'java-clone': check_clone_implementation,
-            'java-codesize': check_code_size,
-            'java-comments': check_comments,
-            'java-controversial': check_controversial,
-            'java-design': check_design,
-            'java-imports': check_imports,
-            'java-naming': check_naming,
-            'java-optimizations': check_optimizations,
-            'java-strings': check_strings,
-            'java-unnecessary': not allow_unnecessary_code,
-            'java-unusedcode': not allow_unused_code}
-        rules = ','.join(key for key in options if options[key])
+        if pmd_config:
+            rules = pmd_config
+        else:
+            options = {
+                'java-basic': check_best_practices,
+                'java-braces': check_braces,
+                'java-clone': check_clone_implementation,
+                'java-codesize': check_code_size,
+                'java-comments': check_comments,
+                'java-controversial': check_controversial,
+                'java-design': check_design,
+                'java-imports': check_imports,
+                'java-naming': check_naming,
+                'java-optimizations': check_optimizations,
+                'java-strings': check_strings,
+                'java-unnecessary': not allow_unnecessary_code,
+                'java-unusedcode': not allow_unused_code}
+            rules = ','.join(key for key in options if options[key])
 
         executable = which('pmd') or which('run.sh')  # Mac vs. Unix
         return executable, 'pmd', '-R', rules, '-d', filename

--- a/tests/java/JavaPMDBearTest.py
+++ b/tests/java/JavaPMDBearTest.py
@@ -1,3 +1,4 @@
+import os
 from bears.java.JavaPMDBear import JavaPMDBear
 from coalib.testing.LocalBearTestHelper import verify_local_bear
 
@@ -23,6 +24,7 @@ bad_file = """
 class Hello {
   int test() {
     String s = null;
+    String bla = new String();
     return s.length();
   }
 }
@@ -32,3 +34,11 @@ class Hello {
 JavaPMDBearTest = verify_local_bear(
     JavaPMDBear, valid_files=(good_file,), invalid_files=(bad_file,),
     tempfile_kwargs={'suffix': '.java'})
+
+test_files = os.path.join(os.path.dirname(__file__), 'test_files')
+custom_rule_set = os.path.join(test_files, 'custom_rule_set.xml')
+
+JavaPMDBearTest2 = verify_local_bear(
+    JavaPMDBear, valid_files=(good_file,), invalid_files=(bad_file,),
+    tempfile_kwargs={'suffix': '.java'},
+    settings={'pmd_config': custom_rule_set})

--- a/tests/java/test_files/custom_rule_set.xml
+++ b/tests/java/test_files/custom_rule_set.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+This is a custom ruleset to validate JavaPMDBear rule set option
+  </description>
+  <rule ref="rulesets/java/strings.xml"/>
+</ruleset>


### PR DESCRIPTION
PMD allows user to supply a custom rule set for it to use when linting.
This change introduces a parameter that enables its usage,
through a custom rule set file.

Closes https://github.com/coala/coala-bears/issues/1700