### PR TITLE
requirements.txt: Use dependency_management 0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE: This file is parsed by .ci/generate_bear_requirements.py
 # Use >= for development versions so that source builds always work
-coala>=0.11.0.dev20170322155718
+coala>=0.11.0.dev20170425001321
 # Dependencies inherited from coala
 # libclang-py3
 # coala_utils


### PR DESCRIPTION
Upgrade to latest pre-release build of coala,
which includes dependency_management 0.4.

Related to https://github.com/coala/coala/issues/4064
