### PR TITLE
KeywordBear: Handle empty keywords

### DIFF
--- a/bears/general/KeywordBear.py
+++ b/bears/general/KeywordBear.py
@@ -96,13 +96,14 @@ class KeywordBear(LocalBear):
         '''
         comments = list(_get_comments(dependency_results))
 
-        simple_keywords_regex = re.compile(
-            '(' + '|'.join(re.escape(key) for key in keywords) + ')',
-            re.IGNORECASE)
+        if keywords:
+            simple_keywords_regex = re.compile(
+                '(' + '|'.join(re.escape(key) for key in keywords) + ')',
+                re.IGNORECASE)
 
-        message = "The line contains the keyword '{}'."
-        yield from self.check_keywords(filename, file, comments,
-                                       simple_keywords_regex, message)
+            message = "The line contains the keyword '{}'."
+            yield from self.check_keywords(filename, file, comments,
+                                           simple_keywords_regex, message)
 
         if regex_keyword is not '':
             regex = re.compile(regex_keyword)

--- a/tests/general/KeywordBearTest.py
+++ b/tests/general/KeywordBearTest.py
@@ -239,3 +239,12 @@ class KeywordBearDiffTest(unittest.TestCase):
                 self.assertIn(log.output[0],
                               'ERROR:root:coalang specification'
                               ' for anything not found.')
+
+    def test_empty_keywords_list(self):
+        self.section.append(Setting('keywords', ''))
+
+        text = ['bears = KeywordBear\n']
+
+        with execute_bear(self.uut, filename='F', file=text,
+                          dependency_results=self.dep_results) as result:
+            self.assertEqual(len(result), 0)


### PR DESCRIPTION
If setting keyword is used in coafile and not assigned, then keywords
is an empty list, which leads to construction of regex `r'()'` which
matches all the letters, hence yielding false results.

Fixes https://github.com/coala/coala-bears/issues/1689

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
