### PR TITLE
SCSSLintBear: Fix result line numbers

### DIFF
--- a/bears/scss/SCSSLintBear.py
+++ b/bears/scss/SCSSLintBear.py
@@ -6,7 +6,8 @@ from dependency_management.requirements.PipRequirement import PipRequirement
 
 
 @linter(executable='scss-lint', output_format='regex',
-        output_regex=r'.+:(?P<line>\d+)\s+\[(?P<severity>.)\]\s*'
+        output_regex=r'.+:(?P<line>\d+):(?P<column>\d+)\s+'
+                     r'\[(?P<severity>.)\]\s+'
                      r'(?P<message>.*)')
 class SCSSLintBear:
     """


### PR DESCRIPTION
The results currently have the column number as the line number.

Fixes https://github.com/coala/coala-bears/issues/1742
