### PR TITLE
CPDBear: Add test for unsupported language

### DIFF
--- a/bears/general/CPDBear.py
+++ b/bears/general/CPDBear.py
@@ -76,7 +76,7 @@ class CPDBear(GlobalBear):
         """
         language = language.lower()
 
-        if language not in self.lowered_lang_dict:  # pragma: no cover
+        if language not in self.lowered_lang_dict:
             self.err('This bear does not support files with the extension '
                      "'{}'.".format(language))
             return

--- a/tests/general/CPDBearTest.py
+++ b/tests/general/CPDBearTest.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 from queue import Queue
+import logging
 
 
 from bears.general.CPDBear import CPDBear
@@ -50,3 +51,17 @@ class CPDBearTest(unittest.TestCase):
         result = list(self.uut.run_bear_from_section([], {}))
 
         self.assertNotEqual(result, [])
+
+    def test_unsupported_language(self):
+        self.section.update_setting(
+            key='language', new_value='unsupported_language')
+
+        self.uut = CPDBear({'file_name': 'hello world  \n'},
+                           self.section,
+                           self.queue)
+
+        list(self.uut.run_bear_from_section([], {}))
+        self.assertEqual(
+            self.uut.message_queue.queue[0].log_level, logging.ERROR)
+        self.assertIn('unsupported_language',
+                      self.uut.message_queue.queue[0].message)


### PR DESCRIPTION
Replace “pragma: no cover” with test for unsupported language

Closes https://github.com/coala/coala-bears/issues/1708

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
