### PR TITLE
GitCommitBear: Fix check if nltk data is needed

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -35,7 +35,7 @@ class GitCommitBear(GlobalBear):
 
     def setup_dependencies(self):
         if not self._nltk_data_downloaded and bool(
-                self.section.get('shortlog_check_imperative', True)):
+                self.section.get('shortlog_imperative_check', True)):
             nltk.download([
                 'punkt',
                 'maxent_treebank_pos_tagger',

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -487,7 +487,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertTrue(GitCommitBear._nltk_data_downloaded)
 
         section = Section('commit')
-        section.append(Setting('shortlog_check_imperative', 'False'))
+        section.append(Setting('shortlog_imperative_check', 'False'))
 
         GitCommitBear._nltk_data_downloaded = False
         GitCommitBear(None, section, self.msg_queue)
@@ -501,7 +501,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertTrue(GitCommitBear._nltk_data_downloaded)
 
         section = Section('commit')
-        section.append(Setting('shortlog_check_imperative', 'True'))
+        section.append(Setting('shortlog_imperative_check', 'True'))
 
         GitCommitBear._nltk_data_downloaded = False
         GitCommitBear(None, section, self.msg_queue)


### PR DESCRIPTION
Use the correct setting `shortlog_imperative_check`
to find out if nltk data is needed.

Fix https://github.com/coala/coala-bears/issues/1760
