### PR TITLE
PythonPackageInitBear.py: Moved docstring from class to 'run' method

### DIFF
--- a/bears/python/PythonPackageInitBear.py
+++ b/bears/python/PythonPackageInitBear.py
@@ -5,9 +5,6 @@ from coalib.bears.GlobalBear import GlobalBear
 
 
 class PythonPackageInitBear(GlobalBear):
-    """
-    Looks for missing __init__.py files in directories containing python files.
-    """
 
     LANGUAGES = {'Python', 'Python 3', 'Python 2'}
     AUTHORS = {'The coala developers'}
@@ -15,6 +12,10 @@ class PythonPackageInitBear(GlobalBear):
     LICENSE = 'AGPL-3.0'
 
     def run(self):
+        """
+        Looks for missing __init__.py files in directories containing python files.
+        """
+
         dirs = {os.path.split(filename)[0]
                 for filename in self.file_dict.keys()
                 if filename.endswith('.py')}


### PR DESCRIPTION
Moved docstring from class to 'run' method to fix issue [ #1500 ](https://github.com/coala/coala-bears/issues/1500)

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
