### PR TITLE
Use codecov-python

### DIFF
--- a/.ci/appveyor.yml
+++ b/.ci/appveyor.yml
@@ -59,3 +59,12 @@ test_script:
   # https://github.com/appveyor/ci/issues/688
   - "%CMD_IN_ENV% python -m pytest --cov -k \"not ClangASTPrintBear and not ClangCloneDetectionBear and not ClangComplexityBear and not ClangCountVectorCreator and not ClangCountingConditions\""
   - "%CMD_IN_ENV% python setup.py install"
+
+on_success:
+  - codecov
+
+on_failure:
+  - codecov
+
+matrix:
+  fast_finish: true

--- a/.ci/deploy.coverage.sh
+++ b/.ci/deploy.coverage.sh
@@ -1,6 +1,0 @@
-set -x
-set -e
-
-source .ci/env_variables.sh
-
-bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ script:
       mv .coafile.new .coafile
     fi
   - coala --non-interactive
-  - bash .ci/deploy.coverage.sh
+  - codecov
   - rm -rf docs/API && make -C docs clean
   - python setup.py docs
 

--- a/circle.yml
+++ b/circle.yml
@@ -59,7 +59,7 @@ test:
         parallel: true
     - coala-ci -L DEBUG:
         parallel: true
-    - bash .ci/deploy.coverage.sh:
+    - codecov:
         parallel: true
     - rm -rf docs/API && make -C docs clean
     - python setup.py docs:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage~=4.2.0
+codecov~=2.0.5
 pytest~=3.0
 pytest-cov~=2.4
 pytest-env~=0.6.0


### PR DESCRIPTION
Currently codecov-bash is used, which involves an uncached fetch
of a unversioned bash script.

Using codecov-python allows the tool to be cached, and greater
reliability due to versioned releases of the tool.

In addition, codecov-bash does not work on Windows, and our
developer base is better tuned to investigate any python
related problems.

Fixes https://github.com/coala/coala/issues/3718
Related to https://github.com/coala/coala-bears/issues/1415
