### PR TITLE
.ci/deps.sh: Fix dartsdk caching

### DIFF
--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -24,7 +24,7 @@ go get -u github.com/BurntSushi/toml/cmd/tomlv
 bundle install --path=vendor/bundle --binstubs=vendor/bin --jobs=8 --retry=3
 
 # Dart Lint commands
-if ! dartanalyzer -v &> /dev/null ; then
+if [ ! -e ~/dart-sdk/lib ]; then
   wget -nc -O ~/dart-sdk.zip https://storage.googleapis.com/dart-archive/channels/stable/release/1.14.2/sdk/dartsdk-linux-x64-release.zip
   unzip -n ~/dart-sdk.zip -d ~/
 fi

--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -29,6 +29,7 @@ if [ ! -e ~/dart-sdk/lib ]; then
   unzip -n ~/dart-sdk.zip -d ~/
 fi
 
+
 # VHDL Bakalint Installation
 if [ ! -e ~/bakalint-0.4.0/bakalint.pl ]; then
   wget "http://downloads.sourceforge.net/project/fpgalibre/bakalint/0.4.0/bakalint-0.4.0.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Ffpgalibre%2Ffiles%2Fbakalint%2F0.4.0%2F&ts=1461844926&use_mirror=netcologne" -O ~/bl.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ cache:
     - ~/pmd-bin-5.4.1
     - ~/bakalint-0.4.0
     - ~/elm-format-0.18
-    - ~/dart-sdk/bin
+    - ~/dart-sdk
     - ~/.local/tailor/
     - ~/phpmd
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     - ~/coala-bears/.bundle
     - ~/coala-bears/vendor
     - ~/.RLibrary
-    - ~/dart-sdk/bin
+    - ~/dart-sdk
     - ~/.cabal
     - ~/.ghc
     - ~/.ghc-mod


### PR DESCRIPTION
`-v` always fails as that is not a valid command line argument.
Use `--version` instead.

Fixes https://github.com/coala/coala-bears/issues/1776