### PR TITLE
HappinessLintBear: Check for use_spaces

### DIFF
--- a/bears/js/HappinessLintBear.py
+++ b/bears/js/HappinessLintBear.py
@@ -20,5 +20,16 @@ class HappinessLintBear:
     CAN_DETECT = {'Syntax'}
 
     @staticmethod
-    def create_arguments(filename, file, config_file):
+    def create_arguments(
+            filename, file, config_file,
+            use_spaces: bool=False):
+
+        # Refer to https://github.com/coala/coala-bears/issues/1754
+        # use_spaces = true conflicts with HappinessLintBear as
+        # it requires tab indentations.
+        if (use_spaces):
+            raise ValueError(
+                'Please set `use_spaces=False` with HappinessLintBear'
+                'to avoid conflicts with other Bears'
+            )
         return filename,

--- a/tests/js/HappinessLintBearTest.py
+++ b/tests/js/HappinessLintBearTest.py
@@ -1,5 +1,11 @@
+from queue import Queue
+
 from bears.js.HappinessLintBear import HappinessLintBear
 from coalib.testing.LocalBearTestHelper import verify_local_bear
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
+from coalib.testing.BearTestHelper import generate_skip_decorator
 
 
 good_file = """
@@ -17,3 +23,18 @@ var x=2
 HappinessLintBearTest = verify_local_bear(HappinessLintBear,
                                           valid_files=(good_file,),
                                           invalid_files=(bad_file,))
+
+
+@generate_skip_decorator(HappinessLintBear)
+class HappinessLintBearConfigTest(LocalBearTestHelper):
+
+    VALUE_ERR_RE = ('Please set `use_spaces=False` with HappinessLintBear'
+                    'to avoid conflicts with other Bears')
+
+    def test_validate_use_spaces(self):
+        section = Section('name')
+        section.append(Setting('use_spaces', True))
+        bear = HappinessLintBear(section, Queue())
+
+        with self.assertRaisesRegex(AssertionError, self.VALUE_ERR_RE):
+            self.check_validity(bear, [], good_file)


### PR DESCRIPTION
Check that value of use_spaces is false for HappinessLintBear because it requires tabbed indentation

Fixes https://github.com/coala/coala-bears/issues/1754

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
