### PR TITLE
VintBear: Deactivate bear

### DIFF
--- a/.ci/tests.sh
+++ b/.ci/tests.sh
@@ -9,4 +9,10 @@ if [ "$system_os" == "LINUX" ] ; then
   args+=('--cov' '--cov-fail-under=100' '--doctest-modules')
 fi
 
+mv bears/vimscript/VintBear.py bears/vimscript/VintBear._py
+mv tests/vimscript/VintBearTest.py tests/vimscript/VintBearTest._py
+
 python3 -m pytest "${args[@]}"
+
+mv bears/vimscript/VintBear._py bears/vimscript/VintBear.py
+mv tests/vimscript/VintBearTest._py tests/vimscript/VintBearTest.py

--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -27,7 +27,6 @@ restructuredtext-lint~=1.0.0
 rstcheck~=2.2
 safety~=0.5.1
 scspell3k~=2.0
-vim-vint~=0.3.10
 vulture~=0.10.0
 yamllint~=1.6.1
 yapf~=0.14.0

--- a/bears/vimscript/VintBear.py
+++ b/bears/vimscript/VintBear.py
@@ -1,5 +1,6 @@
 from coalib.bearlib.abstractions.Linter import linter
-from dependency_management.requirements.PipRequirement import PipRequirement
+from dependency_management.requirements.PackageRequirement import (
+    PackageRequirement)
 
 
 @linter(executable='vint', output_format='regex',
@@ -12,7 +13,7 @@ class VintBear:
     """
 
     LANGUAGES = {'VimScript'}
-    REQUIREMENTS = {PipRequirement('vim-vint', '0.3.10')}
+    REQUIREMENTS = {PackageRequirement('broken', 'vim-vint', '0.3.10')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'


### PR DESCRIPTION
The bear is broken, and it breaks all coala, due to
its requirement chardet~=2.3.0 which is incompatible
with requests adding requirement chardet~=3.0.2.

Related to https://github.com/coala/coala-bears/issues/1785
