### PR TITLE
PycodeStyleBear.py: Use 'typed_list(str)'

### DIFF
--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -1,6 +1,6 @@
 from coalib.bearlib.abstractions.Linter import linter
-
 from dependency_management.requirements.PipRequirement import PipRequirement
+from coalib.settings.Setting import typed_list
 
 
 @linter(executable='pycodestyle',
@@ -21,8 +21,8 @@ class PycodestyleBear:
     @staticmethod
     def create_arguments(
             filename, file, config_file,
-            pycodestyle_ignore: str='',
-            pycodestyle_select: str='',
+            pycodestyle_ignore: typed_list(str)=(),
+            pycodestyle_select: typed_list(str)=(),
             max_line_length: int=79):
         """
         :param pycodestyle_ignore:
@@ -38,10 +38,12 @@ class PycodestyleBear:
         arguments = [r'--format=%(row)d %(col)d %(code)s %(text)s']
 
         if pycodestyle_ignore:
-            arguments.append('--ignore=' + pycodestyle_ignore)
+            ignore = ','.join(part.strip() for part in pycodestyle_ignore)
+            arguments.append('--ignore=' + ignore)
 
         if pycodestyle_select:
-            arguments.append('--select=' + pycodestyle_select)
+            select = ','.join(part.strip() for part in pycodestyle_select)
+            arguments.append('--select=' + select)
 
         arguments.append('--max-line-length=' + str(max_line_length))
 

--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -21,10 +21,11 @@ class PycodestyleBear:
     @staticmethod
     def create_arguments(
             filename, file, config_file,
-            pycodestyle_ignore: typed_list(str)=('E121', 'E123', 'E126', 
-                                                 'E133', 'E226', 'E241', 
-                                                 'E242', 'E704', 'W503'),
-            pycodestyle_select: typed_list(str)=()
+            pycodestyle_ignore: typed_list(str)=(
+                'E121', 'E123', 'E126', 'E133', 'E226', 'E241',
+                'E242', 'E704', 'W503'
+            ),
+            pycodestyle_select: typed_list(str)=(),
             max_line_length: int=79):
         """
         :param pycodestyle_ignore:


### PR DESCRIPTION
Use 'typed_list(str)' instead of plain str

Closes https://github.com/coala/coala-bears/issues/1739

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
