### PR TITLE
VultureBear: Update version of vulture

### DIFF
--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -30,6 +30,6 @@ rstcheck~=3.1
 safety~=0.5.1
 scspell3k~=2.0
 vim-vint~=0.3.12
-vulture~=0.10.0
+vulture~=0.14.0
 yamllint~=1.6.1
 yapf~=0.14.0

--- a/bears/python/VultureBear.py
+++ b/bears/python/VultureBear.py
@@ -9,7 +9,7 @@ from coalib.results.Result import Result
 
 class VultureBear(GlobalBear):
     LANGUAGES = {'Python', 'Python 3'}
-    REQUIREMENTS = {PipRequirement('vulture', '0.10.0')}
+    REQUIREMENTS = {PipRequirement('vulture', '0.14.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'


### PR DESCRIPTION
Since unused_imports was introduced in vulture
0.12.0, update the required verion of vulture
so that VultureBear can make use of vulture API.

Closes: https://github.com/coala/coala-bears/issues/1809

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [X] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [X] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
