### PR TITLE
Use sphinx-1.6.2 for building docs and avoid warnings by cleaning up output_regex of StyleLintBear

### DIFF
--- a/bears/css/StyleLintBear.py
+++ b/bears/css/StyleLintBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
 @linter(executable='stylelint',
         output_format='regex',
         output_regex=r'\s*(?P<filename>.+)\s*(?P<line>\d+):(?P<column>\d+)\s*'
-                     r'(\D)\s*(?P<message>.+)',
+                     r'\D\s*(?P<message>.+)',
         config_suffix='.json')
 class StyleLintBear:
     """

--- a/circle.yml
+++ b/circle.yml
@@ -70,6 +70,12 @@ test:
     # and node 1 has python 3.4.3
     - ? |
           if [ $CIRCLE_NODE_INDEX == 1 ] ; then
+            pip install -r docs-requirements.txt
+          fi
+      :
+        parallel: true
+    - ? |
+          if [ $CIRCLE_NODE_INDEX == 1 ] ; then
             python setup.py docs
           fi
       :

--- a/circle.yml
+++ b/circle.yml
@@ -66,5 +66,11 @@ test:
         parallel: true
     - codecov:
         parallel: true
-    - python setup.py docs:
+    # sphinx fails with python 3.5.1 due to an issue in typing package,
+    # and node 1 has python 3.4.3
+    - ? |
+          if [ $CIRCLE_NODE_INDEX == 1 ] ; then
+            python setup.py docs
+          fi
+      :
         parallel: true

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,1 +1,2 @@
-sphinx==1.3.5
+sphinx~=1.6.2
+sphinx_rtd_theme~=0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE: This file is parsed by .ci/generate_bear_requirements.py
 # Use >= for development versions so that source builds always work
-coala>=0.12.0.dev20170703154304
+coala>=0.12.0.dev20170715183139
 # Dependencies inherited from coala
 # libclang-py3
 # coala_utils


### PR DESCRIPTION
According to https://github.com/coala/coala/pull/4330 and https://github.com/coala/coala/pull/4333

Partial continuation of https://github.com/coala/coala-bears/pull/1569

Closes https://github.com/coala/coala-bears/issues/1554

Fixes https://github.com/coala/coala-bears/issues/1821 as side-effect

And changes `circle.yml` to use Python 3.4.3 for building docs instead of default 3.5.1, since the latter's `typing` package causes recent `sphinx` versions to fail