### PR TITLE
URLBear: Regex for percentage-encoded URLs

### DIFF
--- a/bears/general/URLBear.py
+++ b/bears/general/URLBear.py
@@ -108,12 +108,16 @@ class URLBear(LocalBear):
             [^.:%\s_/?#[\]@\\]+         # Initial part of domain
             \.                          # A required dot `.`
             (
-                (?:[^\s()%\'"`<>|\\\[\]]+)  # Path name
-                                            # This part does not allow
-                                            # any parenthesis: balanced or
-                                            # unbalanced.
-            |                               # OR
-                \([^\s()%\'"`<>|\\\[\]]*\)  # Path name contained within ()
+                ((?:%[A-Fa-f0-9][A-Fa-f0-9])*[^\s()%\'"`<>|\\\[\]]+)
+                                        # Path name
+                                        # This part allows precentage
+                                        # encoding like %3F
+                                        # and does not allow
+                                        # any parenthesis: balanced or
+                                        # unbalanced.
+            |                           # OR
+                \((?:%[A-Fa-f0-9][A-Fa-f0-9])*[^\s()%\'"`<>|\\\[\]]*\)
+                                        # Path name contained within ()
                                         # This part allows path names that
                                         # are explicitly enclosed within one
                                         # set of parenthesis.

--- a/tests/general/URLBearTest.py
+++ b/tests/general/URLBearTest.py
@@ -60,6 +60,23 @@ class URLBearTest(unittest.TestCase):
                              [3, 'http://www.google.com/404',
                               404, LINK_CONTEXT.no_context])
 
+    def test_precentage_encoded_url(self):
+        valid_file = """
+        # A url with a precentage-encoded character in path
+        https://img.shields.io/badge/Maintained%3F-yes-green.svg/200
+        """.splitlines()
+
+        with requests_mock.Mocker() as m:
+            m.add_matcher(custom_matcher)
+
+            result = get_results(self.uut, valid_file)
+            self.assertEqual(result[0].contents,
+                             [3,
+                              ('https://img.shields.io/badge/Maintained%3F-'
+                               'yes-green.svg/200'),
+                              200,
+                              LINK_CONTEXT.no_context])
+
 
 class URLResultTest(unittest.TestCase):
 


### PR DESCRIPTION
Add regex for percentage-encoded URls like
https://img.shields.io/badge/Maintained%3F-yes-green.svg

Fixes https://github.com/coala/coala-bears/issues/1290

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
