### PR TITLE
RubocopBear: Optional generation of `config_file`

### DIFF
--- a/bears/ruby/RuboCopBear.py
+++ b/bears/ruby/RuboCopBear.py
@@ -81,7 +81,8 @@ class RuboCopBear:
                         ignore_unused_block_args_if_empty: bool=True,
                         allow_unused_block_keyword_arguments: bool=False,
                         ignore_unused_method_args_if_empty: bool=True,
-                        allow_unused_method_keyword_args: bool=False):
+                        allow_unused_method_keyword_args: bool=False,
+                        rubocop_config: str=''):
         """
         Not all settings added.
         Notable settings missing: Rails settings.
@@ -174,6 +175,9 @@ class RuboCopBear:
         :param allow_unused_method_keyword_args:
             Allows unused keyword arguments in a method.
         """
+        if rubocop_config:
+            return None
+
         naming_convention = {'camel': 'camelCase', 'snake': 'snake_case'}
         options = {
             'Style/AccessModifierIndentation': {


### PR DESCRIPTION
Generation of `config_file` is only done if `rubocop_config` is
absent as an argument. This is a performance gain since
`config_file` was generated irrespective of `rubocop_config`,
each time the bear was run.

Closes https://github.com/coala/coala-bears/issues/1839

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
