### PR TITLE
.rultor.yml: Do not install pip3

### DIFF
--- a/.ci/deps.pip.sh
+++ b/.ci/deps.pip.sh
@@ -21,7 +21,6 @@ for dep_version in "${dep_versions[@]}" ; do
   pip install -U setuptools
   pip install -r test-requirements.txt
   pip install -r requirements.txt
-  pip install language_check==0.8.*
 done
 
 pip install -r docs-requirements.txt

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -1,10 +1,3 @@
-install:
-  - >
-    if ! pip3 -V ; then
-      wget -O - https://bootstrap.pypa.io/get-pip.py
-      python3 get-pip.py
-    fi
-
 docker:
   as_root: true
   image: "coala/rultor-python"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 python:
   - 3.4
   - 3.5
-  - 3.6
+  - 3.6.1
 
 matrix:
   include:


### PR DESCRIPTION
The docker `coala/rultor-python` installs `pip3`.  If it doesnt,
something larger has failed and installing pip3 isnt going to help.

Related to https://github.com/coala/coala/issues/4393
Fixes https://github.com/coala/coala-bears/issues/1853
