### PR TITLE
ApertiumLintBear: Remove wrong docstring unicode

### DIFF
--- a/bears/apertium/ApertiumLintBear.py
+++ b/bears/apertium/ApertiumLintBear.py
@@ -143,35 +143,35 @@ class ApertiumLintBear:
         :param repeated_entries:
             Checks and reports repeated entries in the bidix.
         :param repeated_entries_cat_item:
-            Simple check which iterates over all the `<cat­item>`s in a
-            `<def­cat>` and detects repeated `<cat­items>`
+            Simple check which iterates over all the `<cat-item>`s in a
+            `<def­-cat>` and detects repeated `<cat-items>`
         :param repeated_entries_attr_item:
-            Again another simple issue that checks for repeated attr­items
-            in def­attr.
+            Again another simple issue that checks for repeated `<attr-item>`s
+            in `<def-attr>`.
         :param unused_def_cats:
-            The lint can now detect and report redundant def­cats that
+            The lint can now detect and report redundant `<def-cat>`s that
             maybe present in the transfer rules definition but are never
             actually used.
         :param check_valid_part_clip:
             Check that the attribute listed in part='xyz' is defined
-            using a `<def­attr>`. The valid parts are defined in def­attrs
+            using a `<def-attr>`. The valid parts are defined in `<def-attr>`s
             section of the transfer file.
         :param check_valid_equal_tag:
             Another common error in transfer files is trying to compare
             an attribute to a value it cannot take.
         :param conflicting_cat_item:
-            This detects and reports if the same cat­item has been used in
-            two or more def­cats.
+            This detects and reports if the same `<cat-item>` has been used in
+            two or more `<def-cat>`s.
         :param check_valid_position:
             Every mention of pos='xyz' is checked to make sure that xyz
-            is less than or equal to the number of elements in pattern ­item.
+            is less than or equal to the number of elements in pattern item.
         :param enforce_break_tag:
             This function reports the if the `<b/>` tags are absent between
             two consecutive `<lu>` tags.
         :param xsd_validation:
             XSD Validation for transfer files, takes care of issues such as
-            Repeated def­cats, Repeated def­attrs, Repeted def­list,
-            Valid side : ‘sl’ or ‘tl’ and Repeated def­macro
+            Repeated `<def-cat>`, `<def-attrs>`, and `<def-list>`.
+            Valid side : `sl` or `tl` and repeated `<def-macro>`.
         :param enforce_side:
             In `<out>` the side attribute can either take the value of 'sl' or
             'tl'. With the lint in place, the user can enforce the side
@@ -181,7 +181,7 @@ class ApertiumLintBear:
         :param defLabel_closed:
             This function lints and reports if any other value has been used
             instead of the two valid ones: [true, false] in the closed
-            attribute in `<def­label>` .
+            attribute in `<def-label>` .
         :param validate_label_sequence:
             This function lints and detects and labels in <forbid> that are
             absent in `<tagset>`.
@@ -190,7 +190,7 @@ class ApertiumLintBear:
             files.
         :param install_bool:
             In modes files, the install attribute can only take one of two
-            binary values, ‘yes’ or ‘no’. This function is responsible for
+            binary values, 'yes' or 'no'. This function is responsible for
             making sure that no other value is used for the same.
         :param repeated_program:
             Every modes file consits of various programs and there is always a
@@ -199,17 +199,17 @@ class ApertiumLintBear:
             This function validates every program mentioned in the modes file.
         :param locate_file:
             This function checks and prompts incase a file defined in a
-            “program” is missing in the PWD.
+            "program" is missing in the `PWD`.
         :param empty_program:
-            Not so much a risk, but this function prompts if a given program
+            Not so much a risk, but this function prompts if a given "program"
             does not have any file associated with it.
         :param enforce_rules:
             This function is responsible for enforcing certain rules specific
             to given programs.
         :param install_switch_no:
-            If in the definition of a certain mode, the attribute install=”no”,
-            the name should have an appropriate suffix like ­morph,
-            interchunk, etc.
+            If in the definition of a certain mode, the attribute
+            `install="no"`, the name should have an appropriate suffix like
+            ­morph, interchunk, etc.
         """
         monodix = {'redundantPardef': {'message': 'Warning : Redundant pardef '
                                        'entry present for :',


### PR DESCRIPTION
The docstring for ApertiumLintBear settings contains incorrect
Unicode symbols, resulting in incorrect rendering and hidden
characters.

Fixes https://github.com/coala/coala-bears/issues/1877