### PR TITLE
URLBear: Create URLResult

### DIFF
--- a/tests/general/URLBearTest.py
+++ b/tests/general/URLBearTest.py
@@ -2,7 +2,8 @@ import unittest
 import requests
 import requests_mock
 
-from bears.general.URLBear import URLBear, LINK_CONTEXT
+from bears.general.URLBear import URLBear, LINK_CONTEXT, URLResult
+from coalib.results.SourceRange import SourceRange
 from coalib.testing.LocalBearTestHelper import get_results
 from coalib.settings.Section import Section
 from queue import Queue
@@ -57,3 +58,45 @@ class URLBearTest(unittest.TestCase):
             self.assertEqual(result[1].contents,
                              [3, 'http://www.google.com/404',
                               404, LINK_CONTEXT.no_context])
+
+
+class URLResultTest(unittest.TestCase):
+
+    def setUp(self):
+        self.affected_code = (SourceRange.from_values('filename', 1),)
+
+    def test_urlresult_wrong_type_link(self):
+        msg = ('link must be an instance of one of '
+               '\(<class \'str\'>,\) \(provided value: 17072017\)')
+        with self.assertRaisesRegex(TypeError, msg):
+            URLResult(URLBear, self.affected_code, 17072017, 1,
+                      LINK_CONTEXT.no_context)
+
+    def test_urlresult_wrong_type_http_status_code(self):
+        msg = ('http_status_code must be an instance of one of '
+               '\(<class \'int\'>, None\) \(provided value: \'1\'\)')
+        with self.assertRaisesRegex(TypeError, msg):
+            URLResult(URLBear, self.affected_code, 'url', '1',
+                      LINK_CONTEXT.no_context)
+
+    def test_urlresult_wrong_type_link_context(self):
+        msg = ('link_context must be an instance of one of '
+               '\(<aenum \'LINK_CONTEXT\'>,\)'
+               ' \(provided value: \'LINK_CONTEXT\.no_context\'\)')
+        with self.assertRaisesRegex(TypeError, msg):
+            URLResult(URLBear, self.affected_code, 'url', 1,
+                      'LINK_CONTEXT.no_context')
+
+    def test_urlresult_object_repr(self):
+        repr_result = repr(URLResult(URLBear, self.affected_code,
+                                     'http://google.com', 200,
+                                     LINK_CONTEXT.no_context))
+        repr_regex = ('<URLResult object\(id=.+, origin=\'bearclass\', '
+                      'affected_code=\(<SourceRange object\(start=<SourcePosit'
+                      'ion object\(file=\'.+\', line=1, column=None\) at .+>, '
+                      'end=<SourcePosition object\(file=\'.+\', line=1, column'
+                      '=None\) at .+>\) at .+>,\), message=\'http://google.com'
+                      ' responds with HTTP 200\', link=\'http://google.com\','
+                      ' http_status_code=200, link_context=<LINK_CONTEXT.no_co'
+                      'ntext: 0>\) at .+>')
+        self.assertRegex(repr_result, repr_regex)


### PR DESCRIPTION
Create URLResult in URLBear.py and replace HiddenResult
with URLResult, so other bears which depends on this bear
can fetch the value through attributes instead of `contents`.

Closes https://github.com/coala/coala-bears/issues/1902

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
