### PR TITLE
DocumentationStyleBear: Use DocBaseClass

### DIFF
--- a/bears/documentation/DocumentationStyleBear.py
+++ b/bears/documentation/DocumentationStyleBear.py
@@ -2,15 +2,15 @@ from coalib.bearlib.languages.documentation.DocumentationComment import (
     DocumentationComment)
 from coalib.bearlib.languages.documentation.DocstyleDefinition import (
     DocstyleDefinition)
-from coalib.bearlib.languages.documentation.DocumentationExtraction import (
-    extract_documentation)
+from coalib.bearlib.languages.documentation.DocBaseClass import (
+    DocBaseClass)
 from coalib.bears.LocalBear import LocalBear
-from coalib.results.Diff import Diff
 from coalib.results.Result import Result
-from coalib.results.TextRange import TextRange
+
+from textwrap import dedent
 
 
-class DocumentationStyleBear(LocalBear):
+class DocumentationStyleBear(DocBaseClass, LocalBear):
     LANGUAGES = {language for docstyle, language in
                  DocstyleDefinition.get_available_definitions()}
     AUTHORS = {'The coala developers'}
@@ -19,6 +19,71 @@ class DocumentationStyleBear(LocalBear):
     ASCIINEMA_URL = 'https://asciinema.org/a/7sfk3i9oxs1ixg2ncsu3pym0u'
     CAN_DETECT = {'Documentation'}
     CAN_FIX = {'Documentation'}
+
+    def process_documentation(self, parsed, allow_missing_func_desc: str=False,
+                              indent_size: int=4):
+        """
+        This fixes the parsed documentation comment.
+
+        :param parsed:
+            Contains parsed documentation comment.
+        :param allow_missing_func_desc:
+            When set ``True`` this will allow functions with missing
+            descriptions, allowing functions to start with params.
+        :param indent_size:
+            Number of spaces per indentation level.
+        :return:
+            A tuple of fixed parsed documentation comment and warning_desc.
+        """
+        # Assuming that the first element is always the only main
+        # description.
+        metadata = iter(parsed)
+
+        main_description = next(metadata)
+
+        if main_description.desc == '\n' and not allow_missing_func_desc:
+            # Triple quoted string literals doesn't look good. It breaks
+            # the line of flow. Hence we use dedent.
+            warning_desc = dedent("""\
+            Missing function description.
+            Please set allow_missing_func_desc = True to ignore this warning.
+            """)
+        else:
+            warning_desc = 'Documentation does not have correct style.'
+
+        # one empty line shall follow main description (except it's empty
+        # or no annotations follow).
+        if main_description.desc.strip() != '':
+            main_description = main_description._replace(
+                desc='\n' + main_description.desc.strip() + '\n' *
+                     (1 if len(parsed) == 1 else 2))
+
+        new_metadata = [main_description]
+        for m in metadata:
+            # Split newlines and remove leading and trailing whitespaces.
+            stripped_desc = list(map(str.strip, m.desc.splitlines()))
+            if len(stripped_desc) == 0:
+                # Annotations should be on their own line, though no
+                # further description follows.
+                stripped_desc.append('')
+            else:
+                # Wrap parameter description onto next line if it follows
+                # annotation directly.
+                if stripped_desc[0] != '':
+                    stripped_desc.insert(0, '')
+
+            # Indent with 4 spaces.
+            stripped_desc = ('' if line == '' else ' ' * indent_size
+                             + line for line in stripped_desc)
+
+            new_desc = '\n'.join(stripped_desc)
+
+            # Strip away trailing whitespaces and obsolete newlines (except
+            # one newline which is mandatory).
+            new_desc = new_desc.rstrip() + '\n'
+
+            new_metadata.append(m._replace(desc=new_desc.lstrip(' ')))
+        return (new_metadata, warning_desc)
 
     def run(self, filename, file, language: str,
             docstyle: str='default', allow_missing_func_desc: str=False,
@@ -46,55 +111,12 @@ class DocumentationStyleBear(LocalBear):
                          functions to start with params.
         :param indent_size: Number of spaces per indentation level.
         """
-        for doc_comment in extract_documentation(file, language, docstyle):
+
+        for doc_comment in self.extract(file, language, docstyle):
             parsed = doc_comment.parse()
-            metadata = iter(parsed)
 
-            # Assuming that the first element is always the only main
-            # description.
-            main_description = next(metadata)
-
-            if main_description.desc == '\n' and not allow_missing_func_desc:
-                warning_desc = """
-Missing function description.
-Please set allow_missing_func_desc = True to ignore this warning.
-"""
-            else:
-                warning_desc = 'Documentation does not have correct style.'
-
-            # one empty line shall follow main description (except it's empty
-            # or no annotations follow).
-            if main_description.desc.strip() != '':
-                main_description = main_description._replace(
-                    desc='\n' + main_description.desc.strip() + '\n' *
-                         (1 if len(parsed) == 1 else 2))
-
-            new_metadata = [main_description]
-            for m in metadata:
-                # Split newlines and remove leading and trailing whitespaces.
-                stripped_desc = list(map(str.strip, m.desc.splitlines()))
-
-                if len(stripped_desc) == 0:
-                    # Annotations should be on their own line, though no
-                    # further description follows.
-                    stripped_desc.append('')
-                else:
-                    # Wrap parameter description onto next line if it follows
-                    # annotation directly.
-                    if stripped_desc[0] != '':
-                        stripped_desc.insert(0, '')
-
-                # Indent with 4 spaces.
-                stripped_desc = ('' if line == '' else ' ' * indent_size
-                                 + line for line in stripped_desc)
-
-                new_desc = '\n'.join(stripped_desc)
-
-                # Strip away trailing whitespaces and obsolete newlines (except
-                # one newline which is mandatory).
-                new_desc = new_desc.rstrip() + '\n'
-
-                new_metadata.append(m._replace(desc=new_desc.lstrip(' ')))
+            (new_metadata, warning_desc) = self.process_documentation(
+                                parsed, allow_missing_func_desc, indent_size)
 
             new_comment = DocumentationComment.from_metadata(
                 new_metadata, doc_comment.docstyle_definition,
@@ -102,16 +124,7 @@ Please set allow_missing_func_desc = True to ignore this warning.
 
             if new_comment != doc_comment:
                 # Something changed, let's apply a result.
-                diff = Diff(file)
-
-                # We need to update old comment positions, as `assemble()`
-                # prepends indentation for first line.
-                old_range = TextRange.from_values(
-                    doc_comment.range.start.line,
-                    1,
-                    doc_comment.range.end.line,
-                    doc_comment.range.end.column)
-                diff.replace(old_range, new_comment.assemble())
+                diff = self.generate_diff(file, doc_comment, new_comment)
 
                 yield Result(
                     origin=self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE: This file is parsed by .ci/generate_bear_requirements.py
 # Use >= for development versions so that source builds always work
-coala>=0.12.0.dev20170715183139
+coala>=0.12.0.dev20170722091132
 # Dependencies inherited from coala
 # libclang-py3
 # coala_utils


### PR DESCRIPTION
DocumentationStyleBear uses DocBaseClass.
Closes https://github.com/coala/coala-bears/issues/1927

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
