### PR TITLE
DocumentationStyleBear: Add expand_one_liners

### DIFF
--- a/tests/documentation/DocumentationStyleBearTest.py
+++ b/tests/documentation/DocumentationStyleBearTest.py
@@ -16,13 +16,13 @@ def load_testfile(filename):
         return fl.read()
 
 
-def test(test_file, expected_file):
+def test(test_file, expected_file, optional_setting=None):
     def test_function(self):
         test_file_content = load_testfile(test_file).splitlines(True)
 
         arguments = {'language': 'python', 'docstyle': 'default'}
-        if test_file == 'good_file3.py.test':
-            arguments.update({'allow_missing_func_desc': 'True'})
+        if optional_setting:
+            arguments.update(optional_setting)
         section = Section('test-section')
         for key, value in arguments.items():
             section[key] = value
@@ -49,10 +49,13 @@ def test(test_file, expected_file):
 
 class DocumentationStyleBearTest(unittest.TestCase):
     test_bad1 = test('bad_file.py.test', 'bad_file.py.test.correct')
-    test_bad2 = test('bad_file2.py.test', 'bad_file2.py.test.correct')
-    test_bad3 = test('bad_file3.py.test', 'bad_file3.py.test.correct')
+    test_bad2 = test('bad_file2.py.test', 'bad_file2.py.test.correct',
+                     {'expand_one_liners': 'True'})
+    test_bad3 = test('bad_file3.py.test', 'bad_file3.py.test.correct',
+                     {'expand_one_liners': 'True'})
     test_bad4 = test('bad_file4.py.test', 'bad_file4.py.test.correct')
     test_bad5 = test('bad_file5.py.test', 'bad_file5.py.test.correct')
     test_good1 = test('good_file.py.test', 'good_file.py.test')
     test_good2 = test('good_file2.py.test', 'good_file2.py.test')
-    test_good3 = test('good_file3.py.test', 'good_file3.py.test')
+    test_good3 = test('good_file3.py.test', 'good_file3.py.test',
+                      {'allow_missing_func_desc': 'True'})

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file5.py.test
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file5.py.test
@@ -7,3 +7,12 @@ def docstring_improper_alignment():
     :param x:
     :return:
     """ return None
+
+""" This is one liner having extra whitespaces   """
+
+"""
+This is malformed one liner docstring"""
+
+"""
+This is multi-liner docstring
+"""

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file5.py.test.correct
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file5.py.test.correct
@@ -7,3 +7,9 @@ def docstring_improper_alignment():
     :param x:
     :return:
     """ return None
+
+"""This is one liner having extra whitespaces"""
+
+"""This is malformed one liner docstring"""
+
+"""This is multi-liner docstring"""

--- a/tests/documentation/test_files/DocumentationStyleBear/good_file3.py.test
+++ b/tests/documentation/test_files/DocumentationStyleBear/good_file3.py.test
@@ -4,3 +4,5 @@ def docstring_missing_description(dummy):
         a function starting with `param`
         in this case allow_missing_func_desc = True
     """
+
+"""This is one-liner docstring"""


### PR DESCRIPTION
Add expand_one_liners setting which will expand one
liners to multi line docstring.

Closes https://github.com/coala/coala-bears/issues/1856

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
