### PR TITLE
DocumentationStyleBear: Add blankline check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE: This file is parsed by .ci/generate_bear_requirements.py
 # Use >= for development versions so that source builds always work
-coala>=0.12.0.dev20170817142835
+coala>=0.12.0.dev20170818161816
 # Dependencies inherited from coala
 # libclang-py3
 # coala_utils

--- a/tests/documentation/DocumentationStyleBearTest.py
+++ b/tests/documentation/DocumentationStyleBearTest.py
@@ -78,6 +78,8 @@ class DocumentationStyleBearTest(unittest.TestCase):
     test_good2 = test('good_file2.py.test', 'good_file2.py.test')
     test_good3 = test('good_file3.py.test', 'good_file3.py.test',
                       {'allow_missing_func_desc': 'True'})
+    test_bad_java = test('bad_file.java.test', 'bad_file.java.test.correct',
+                         {'language': 'java'})
 
     test_malformed_comment_python = test_MalformedComment(
         ['"""\n',

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file.java.test
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file.java.test
@@ -1,0 +1,15 @@
+class HelloWorld {
+
+   /**
+    *Java docstyle test.
+    *There's no official standard for how paddings are in java.
+    *Hence, in this case paddings are preserved as original.
+    *
+    *@param  name the name to which to say hello
+    *@raises  IOException throws IOException
+    *@return      the concatenated string
+    */
+    public String sayHello(String name) throws IOException {
+        return "Hello, " + name;
+    }
+}

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file.java.test.correct
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file.java.test.correct
@@ -1,0 +1,18 @@
+class HelloWorld {
+
+   /**
+    *Java docstyle test.
+    *There's no official standard for how paddings are in java.
+    *Hence, in this case paddings are preserved as original.
+    *
+    *@param  name 
+    *    the name to which to say hello
+    *@raises  IOException 
+    *    throws IOException
+    *@return 
+    *    the concatenated string
+    */
+    public String sayHello(String name) throws IOException {
+        return "Hello, " + name;
+    }
+}

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file2.py.test
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file2.py.test
@@ -14,6 +14,7 @@ def docstring_testcase(dummy):
 def docstring_singleliner():
     """ This is singleliner docstring. """
 
+    return None
 
 def docstring_inline():
     """

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file2.py.test.correct
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file2.py.test.correct
@@ -17,7 +17,7 @@ def docstring_singleliner():
     """
     This is singleliner docstring.
     """
-
+    return None
 
 def docstring_inline():
     """

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file3.py.test
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file3.py.test
@@ -30,9 +30,11 @@ class docstring_if_indented():
             """
             This is `if` indented block function.
             """
+            return None
     else:
         def hello_venus(self):
             """This is `if` indented block function."""
+            return None
 
 
 def docstring_inner_function(dummy):

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file3.py.test.correct
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file3.py.test.correct
@@ -41,11 +41,13 @@ class docstring_if_indented():
             """
             This is `if` indented block function.
             """
+            return None
     else:
         def hello_venus(self):
             """
             This is `if` indented block function.
             """
+            return None
 
 
 def docstring_inner_function(dummy):

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file4.py.test
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file4.py.test
@@ -7,3 +7,28 @@ def docstring_missing_descriptions(a, b, x):
     :return:"""
 
     return a * x + b
+
+
+class docstring_class_improper_paddings(dummy):
+
+    """
+    Docstring has improper paddings. `class` type docstrings
+    should be followed by 1 blank line at the bottom.
+
+    :param dummy:
+        dummy description.
+    """
+
+
+    def docstring_function_improper_paddings:
+
+        """
+        Docstring has improper paddings. `function` type docstrings
+        should never be followed by any blank lines.
+
+        :return:
+            None
+        """
+
+
+        return None

--- a/tests/documentation/test_files/DocumentationStyleBear/bad_file4.py.test.correct
+++ b/tests/documentation/test_files/DocumentationStyleBear/bad_file4.py.test.correct
@@ -8,5 +8,24 @@ def docstring_missing_descriptions(a, b, x):
     :param x:
     :return:
     """
-
     return a * x + b
+
+
+class docstring_class_improper_paddings(dummy):
+    """
+    Docstring has improper paddings. `class` type docstrings
+    should be followed by 1 blank line at the bottom.
+
+    :param dummy:
+        dummy description.
+    """
+
+    def docstring_function_improper_paddings:
+        """
+        Docstring has improper paddings. `function` type docstrings
+        should never be followed by any blank lines.
+
+        :return:
+            None
+        """
+        return None

--- a/tests/documentation/test_files/DocumentationStyleBear/good_file3.py.test
+++ b/tests/documentation/test_files/DocumentationStyleBear/good_file3.py.test
@@ -4,5 +4,6 @@ def docstring_missing_description(dummy):
         a function starting with `param`
         in this case allow_missing_func_desc = True
     """
+    return None
 
 """This is one-liner docstring"""


### PR DESCRIPTION
DocumentationStyleBear now checks for blankline
before and after the docstring and fixes them.

Closes https://github.com/coala/coala/issues/4200

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
