### PR TITLE
GitCommitBear: Remove unnecessary tagger data

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -38,7 +38,6 @@ class GitCommitBear(GlobalBear):
                 self.section.get('shortlog_imperative_check', True)):
             nltk.download([
                 'punkt',
-                'maxent_treebank_pos_tagger',
                 'averaged_perceptron_tagger',
             ])
             type(self)._nltk_data_downloaded = True


### PR DESCRIPTION
NLTK data package maxent_treebank_pos_tagger is not used.

Closes https://github.com/coala/coala-bears/issues/1974

