### PR TITLE
DocStyleBear: Add `MalformedComment` support

### DIFF
--- a/bears/documentation/DocumentationStyleBear.py
+++ b/bears/documentation/DocumentationStyleBear.py
@@ -1,5 +1,5 @@
 from coalib.bearlib.languages.documentation.DocumentationComment import (
-    DocumentationComment)
+    DocumentationComment, MalformedComment)
 from coalib.bearlib.languages.documentation.DocstyleDefinition import (
     DocstyleDefinition)
 from coalib.bearlib.languages.documentation.DocBaseClass import (
@@ -124,22 +124,29 @@ class DocumentationStyleBear(DocBaseClass, LocalBear):
         """
 
         for doc_comment in self.extract(file, language, docstyle):
-            parsed = doc_comment.parse()
-
-            (new_metadata, warning_desc) = self.process_documentation(
-                                parsed, allow_missing_func_desc, indent_size,
-                                expand_one_liners)
-
-            new_comment = DocumentationComment.from_metadata(
-                new_metadata, doc_comment.docstyle_definition,
-                doc_comment.marker, doc_comment.indent, doc_comment.position)
-
-            if new_comment != doc_comment:
-                # Something changed, let's apply a result.
-                diff = self.generate_diff(file, doc_comment, new_comment)
-
-                yield Result(
+            if isinstance(doc_comment, MalformedComment):
+                yield Result.from_values(
                     origin=self,
-                    message=warning_desc,
-                    affected_code=(diff.range(filename),),
-                    diffs={filename: diff})
+                    message=doc_comment.message,
+                    file=filename,
+                    line=doc_comment.line + 1)
+            else:
+                parsed = doc_comment.parse()
+
+                (new_metadata, warning_desc) = self.process_documentation(
+                            parsed, allow_missing_func_desc, indent_size,
+                            expand_one_liners)
+
+                new_comment = DocumentationComment.from_metadata(
+                    new_metadata, doc_comment.docstyle_definition,
+                    doc_comment.marker, doc_comment.indent,
+                    doc_comment.position)
+
+                if new_comment != doc_comment:
+                    # Something changed, let's apply a result.
+                    diff = self.generate_diff(file, doc_comment, new_comment)
+                    yield Result(
+                        origin=self,
+                        message=warning_desc,
+                        affected_code=(diff.range(filename),),
+                        diffs={filename: diff})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # NOTE: This file is parsed by .ci/generate_bear_requirements.py
 # Use >= for development versions so that source builds always work
-coala>=0.12.0.dev20170729102215
+coala>=0.12.0.dev20170817142835
 # Dependencies inherited from coala
 # libclang-py3
 # coala_utils


### PR DESCRIPTION
DocStyleBear will use new error handling mechanism
`MalformedComment`. And yield a `RESULT` with a
message containing error details.

Related to https://github.com/coala/coala/issues/4548

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
