### PR TITLE
URLBearTest: Improve self.assertTrue() statement

### DIFF
--- a/tests/general/URLBearTest.py
+++ b/tests/general/URLBearTest.py
@@ -15,13 +15,14 @@ class URLBearTestPrerequisites(unittest.TestCase):
     def test_check_prerequisites(self):
         with requests_mock.Mocker() as m:
             m.add_matcher(custom_matcher)
-            self.assertTrue(URLBear.check_prerequisites())
+            self.assertEqual(URLBear.check_prerequisites(),
+                             'You are not connected to the internet.')
 
             m.head(URLBear.check_connection_url,
                    exc=requests.exceptions.RequestException)
 
-            self.assertTrue(URLBear.check_prerequisites() ==
-                            'You are not connected to the internet.')
+            self.assertEqual(URLBear.check_prerequisites(),
+                             'You are not connected to the internet.')
 
 
 class URLBearTest(unittest.TestCase):


### PR DESCRIPTION
This is to avoid the test from passing when
self.check_prerequisites returns
'you are not connected to the internet'.
Test will pass only if True is returned.

Closes https://github.com/coala/coala-bears/issues/1998

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
