### PR TITLE
Line Break Correction in ApertiumLintBear.py

### DIFF
--- a/bears/apertium/ApertiumLintBear.py
+++ b/bears/apertium/ApertiumLintBear.py
@@ -193,7 +193,7 @@ class ApertiumLintBear:
             binary values, 'yes' or 'no'. This function is responsible for
             making sure that no other value is used for the same.
         :param repeated_program:
-            Every modes file consits of various programs and there is always a
+            Every modes file consists of various programs and there is always a
             chance that a certain program may unintentionally get repeated.
         :param validate_program:
             This function validates every program mentioned in the modes file.
@@ -217,7 +217,7 @@ class ApertiumLintBear:
                    'paradigmNames': {'message': 'Warning : Improper paradigm '
                                      'name found :',
                                      'enable': paradigm_names},
-                   'rTagData': {'message': 'Warning : Inconsitency in <r> '
+                   'rTagData': {'message': 'Warning : Inconsistency in <r> '
                                 'text for pardef :',
                                 'enable': r_tag_data},
                    'repeatedAttributesPardef': {'message': 'Warning : Repeated'

--- a/bears/apertium/ApertiumLintBear.py
+++ b/bears/apertium/ApertiumLintBear.py
@@ -101,8 +101,7 @@ class ApertiumLintBear:
         :param repeated_attributes_pardef:
             This issue is responsible for checking any repeated entries in
             the attributes associated with an entry in the parameter
-            definition section
-            n monodix files.
+            definition in monodix files.
         :param repeated_entries_pardef:
             This issue is responsible for detecting repeated entries in the
             parameter definition entries for a given paradigm in monodix files.


### PR DESCRIPTION
Closes https://github.com/coala/coala-bears/issues/1965
<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

With reference to issue https://github.com/coala/coala-bears/issues/1965
I have made the required correction:
```
:param repeated_attributes_pardef:
            This issue is responsible for checking any repeated entries in
            the attributes associated with an entry in the parameter
            definition section
            n monodix files.
```

is corrected to :
```

:param repeated_attributes_pardef:
            This issue is responsible for checking any repeated entries in
            the attributes associated with an entry in the parameter
            definition in monodix files.
```
