### PR TITLE
.ci/deps.opam.sh: Pin easy-format to v1.2.0

### DIFF
--- a/.ci/deps.opam.sh
+++ b/.ci/deps.opam.sh
@@ -10,8 +10,16 @@ if [ ! -e ~/infer-linux64-v0.7.0/infer/bin ]; then
   cd ~/infer-linux64-v0.7.0
   opam init --y
   opam update
+
+  # See https://github.com/coala/coala-bears/issues/1763
   opam pin add --yes --no-action atdgen 1.10.0
+
+  # See https://github.com/coala/coala-bears/issues/2059
+  opam pin add --yes --no-action easy-format 1.2.0
+
+  # See https://github.com/coala/coala-bears/issues/1763
   opam pin add --yes --no-action reason 1.13.5
+
   opam pin add --yes --no-action infer .
   opam install --deps-only --yes infer
   ./build-infer.sh java


### PR DESCRIPTION
Infer compilation fails when using easy-format v1.3.0

Fixes https://github.com/coala/coala-bears/issues/2059
