### PR TITLE
PySafetyBear.py: PySafetyBear fail due to KEYERROR

### DIFF
--- a/bears/python/requirements/PySafetyBear.py
+++ b/bears/python/requirements/PySafetyBear.py
@@ -77,7 +77,7 @@ class PySafetyBear(LocalBear):
             yield Result(
                 self,
                 message_template.format(vuln=vulnerability),
-                additional_info=vulnerability.description,
+                additional_info=vulnerability.data['advisory'],
                 affected_code=(source_range, ),
             )
 

--- a/tests/python/requirements/PySafetyBearTest.py
+++ b/tests/python/requirements/PySafetyBearTest.py
@@ -23,7 +23,7 @@ class PySafetyBearTest(LocalBearTestHelper):
 
     def test_with_vulnerability(self):
         vuln_data = {
-            'description': 'foo',
+            'advisory': 'foo',
             'changelog': 'bar',
         }
         with mock.patch(
@@ -35,7 +35,7 @@ class PySafetyBearTest(LocalBearTestHelper):
 
     def test_with_cve_vulnerability(self):
         vuln_data = {
-            'description': 'foo',
+            'advisory': 'foo',
             'cve': 'CVE-2016-9999',
         }
         with mock.patch(


### PR DESCRIPTION
`KeyError` raises because in `insecure_full.json` the `description` key has been replaced with `advisory`
As `pyupio` organisation updated their `insecure_fuul.json` and replaced `dictionary` key with `advisory` key in their `safety` repo also its a live json. First I fetched the `advisory` key form  #`insecure_full.json` in `PySafetyBear.py` and  changed all the `description` key with `advisory`  key in `PySafetyBearTest.py`, it will remove the `keyError`


Fixes https://github.com/coala/coala-bears/issues/2085
