### PR TITLE
PySafetyBear.py: PySafetyBear fail due to KeyError

### DIFF
--- a/bears/python/requirements/PySafetyBear.py
+++ b/bears/python/requirements/PySafetyBear.py
@@ -74,12 +74,20 @@ class PySafetyBear(LocalBear):
                 version_spec_match.end(1) + 1,
             )
 
-            yield Result(
-                self,
-                message_template.format(vuln=vulnerability),
-                additional_info=vulnerability.description,
-                affected_code=(source_range, ),
-            )
+            try:
+                yield Result(
+                    self,
+                    message_template.format(vuln=vulnerability),
+                    additional_info=vulnerability.description,
+                    affected_code=(source_range, ),
+                )
+            except KeyError:
+                yield Result(
+                    self,
+                    message_template.format(vuln=vulnerability),
+                    additional_info='',
+                    affected_code=(source_range, ),
+                )
 
     @staticmethod
     def try_parse_requirements(lines: typed_list(str)):

--- a/tests/python/requirements/PySafetyBearTest.py
+++ b/tests/python/requirements/PySafetyBearTest.py
@@ -60,3 +60,16 @@ class PySafetyBearTest(LocalBearTestHelper):
         ) as check:
             self.check_validity(self.uut, ['foo', 'bar>2'])
             assert not check.called
+
+    def test_with_no_description(self):
+        vuln_data = {
+            'cve': 'CVE-2016-9999',
+        }
+        with mock.patch(
+            'bears.python.requirements.PySafetyBear.safety.check',
+            return_value=[Vulnerability(
+                'baz', '<0.12.10', '0.10.0', vuln_data)],
+        ) as check:
+            self.check_invalidity(self.uut, ['baz==0.10.0', '-e .'])
+            check.assert_called_once_with(packages=[Package(
+                'baz', '0.10.0')])


### PR DESCRIPTION
Last test to check the `opam.sh`  error in log , Don't close till Circle CI show any log