### PR TITLE
CPPLintBear.py: Verify indentation and spaces

### DIFF
--- a/bears/c_languages/CPPLintBear.py
+++ b/bears/c_languages/CPPLintBear.py
@@ -3,6 +3,12 @@ from dependency_management.requirements.PipRequirement import PipRequirement
 from coalib.settings.Setting import typed_list
 
 
+def check_invalid_configuration(indent_size, use_spaces):
+    if indent_size != 2 or not use_spaces:
+        raise ValueError('CPPLint only supports an indentation size of 2, '
+                         'using only spaces.')
+
+
 @linter(executable='cpplint',
         use_stdout=False,
         use_stderr=True,
@@ -26,12 +32,17 @@ class CPPLintBear:
     def create_arguments(filename, file, config_file,
                          max_line_length: int=79,
                          cpplint_ignore: typed_list(str)=(),
-                         cpplint_include: typed_list(str)=()):
+                         cpplint_include: typed_list(str)=(),
+                         indent_size: int=2,
+                         use_spaces: bool=True):
         """
         :param max_line_length: Maximum number of characters for a line.
         :param cpplint_ignore:  List of checkers to ignore.
         :param cpplint_include: List of checkers to explicitly enable.
+        :param indent_size:     Only an indent size of 2 is permitted.
+        :param use_spaces:      Only the value `True` is permitted.
         """
+        check_invalid_configuration(indent_size, use_spaces)
         ignore = ','.join('-'+part.strip() for part in cpplint_ignore)
         include = ','.join('+'+part.strip() for part in cpplint_include)
         return ('--filter=' + ignore + ',' + include,

--- a/tests/c_languages/CPPLintBearTest.py
+++ b/tests/c_languages/CPPLintBearTest.py
@@ -1,5 +1,12 @@
+from queue import Queue
+
 from bears.c_languages.CPPLintBear import CPPLintBear
-from coalib.testing.LocalBearTestHelper import verify_local_bear
+from coalib.testing.LocalBearTestHelper import (verify_local_bear,
+                                                LocalBearTestHelper)
+from coalib.testing.BearTestHelper import generate_skip_decorator
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
+
 
 test_file = """
 int main() {
@@ -26,3 +33,23 @@ CPPLintBearLineLengthConfigTest = verify_local_bear(
     settings={'cpplint_ignore': 'legal',
               'max_line_length': '13'},
     tempfile_kwargs={'suffix': '.cpp'})
+
+
+@generate_skip_decorator(CPPLintBear)
+class CPPLintBearTest(LocalBearTestHelper):
+
+    CPP_VALUE_ERROR_RE = 'Bear returned None on execution'
+
+    def setUp(self):
+        self.section = Section('test section')
+        self.uut = CPPLintBear(self.section, Queue())
+
+    def test_config_failure_indent_size(self):
+        self.section.append(Setting('indent_size', 3))
+        with self.assertRaisesRegex(AssertionError, self.CPP_VALUE_ERROR_RE):
+            self.check_validity(self.uut, [], test_file)
+
+    def test_config_failure_use_spaces(self):
+        self.section.append(Setting('use_spaces', False))
+        with self.assertRaisesRegex(AssertionError, self.CPP_VALUE_ERROR_RE):
+            self.check_validity(self.uut, [], test_file)


### PR DESCRIPTION
`cpplint` only performs indentation checking using 2 spaces, according
to https://google.github.io/styleguide/cppguide.html#Spaces_vs._Tabs
Add check_invalid_configuration function to CPPLintBear.py.
Add tests for invalid configurations.

Fixes https://github.com/coala/coala-bears/issues/896

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
