### PR TITLE
GitCommitBear: Fix behaviour for empty body

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -299,7 +299,8 @@ class GitCommitBear(GlobalBear):
             return
 
         if body_close_issue_on_last_line:
-            body = body.splitlines()[-1]
+            if body:
+                body = body.splitlines()[-1]
             result_message = ('Body of HEAD commit does not contain any {} '
                               'reference in the last line.')
         else:

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -334,6 +334,12 @@ class GitCommitBearTest(unittest.TestCase):
                              body_close_issue_on_last_line=True), [])
         self.assert_no_msgs()
 
+        # No keywords, no issues, no body
+        self.git_commit('Shortlog only')
+        self.assertEqual(self.run_uut(body_close_issue=True,
+                                      body_close_issue_on_last_line=True), [])
+        self.assert_no_msgs()
+
         # Has keyword but no valid issue URL
         self.git_commit('Shortlog\n\n'
                         'First line, blablablablablabla.\n'


### PR DESCRIPTION
The bear raised an exception when only the shortlog was included
in the commit message. This commit is meant to fix this bug.

Fixes https://github.com/coala/coala-bears/issues/2031