### PR TITLE
DuplicatefileBearTest.py: use assertEqual instead assertEquals

### DIFF
--- a/tests/general/DuplicatefileBearTest.py
+++ b/tests/general/DuplicatefileBearTest.py
@@ -44,22 +44,22 @@ class DuplicateFileBearTest(unittest.TestCase):
             'smallFirst.txt'), combined.split())
         self.assertIn(get_absolute_test_path(
             'smallSecond.txt'), combined.split())
-        self.assertEquals(results[0].severity, RESULT_SEVERITY.INFO)
+        self.assertEqual(results[0].severity, RESULT_SEVERITY.INFO)
 
     def test_results_no_duplicates(self):
         results = self.get_results([self.test_files[2],
                                     self.test_files[3]])
         messages = [result.message for result in results]
-        self.assertEquals(messages, [])
+        self.assertEqual(messages, [])
 
     def test_results_empty(self):
         results = self.get_results([])
         messages = [result.message for result in results]
-        self.assertEquals(messages, ['You did not add any file to compare'])
-        self.assertEquals(results[0].severity, RESULT_SEVERITY.MAJOR)
+        self.assertEqual(messages, ['You did not add any file to compare'])
+        self.assertEqual(results[0].severity, RESULT_SEVERITY.MAJOR)
 
     def test_result_single(self):
         results = self.get_results([self.test_files[0]])
         messages = [result.message for result in results]
-        self.assertEquals(messages, ['You included only one file'])
-        self.assertEquals(results[0].severity, RESULT_SEVERITY.MAJOR)
+        self.assertEqual(messages, ['You included only one file'])
+        self.assertEqual(results[0].severity, RESULT_SEVERITY.MAJOR)


### PR DESCRIPTION
fixes https://github.com/coala/coala-bears/issues/2050

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
