### PR TITLE
CPPCheckBear.py: Make CPPCheckBear a GlobalBear

### DIFF
--- a/bears/c_languages/CPPCheckBear.py
+++ b/bears/c_languages/CPPCheckBear.py
@@ -8,6 +8,7 @@ from coalib.settings.Setting import typed_list
 @linter(executable='cppcheck',
         use_stdout=False,
         use_stderr=True,
+        global_bear=True,
         output_format='regex',
         output_regex=r'(?P<line>\d+):(?P<severity>[a-zA-Z]+):'
                      r'(?P<origin>[a-zA-Z]+):(?P<message>.*)',
@@ -27,8 +28,7 @@ class CPPCheckBear:
     LICENSE = 'AGPL-3.0'
     CAN_DETECT = {'Security', 'Unused Code', 'Unreachable Code', 'Smell'}
 
-    @staticmethod
-    def create_arguments(filename, file, config_file,
+    def create_arguments(self, config_file,
                          enable: typed_list(str)=[]):
         """
         :param enable:
@@ -38,8 +38,9 @@ class CPPCheckBear:
             missingInclude
         """
         args = ('--template={line}:{severity}:{id}:{message}',)
+        files = tuple(self.file_dict.keys())
 
         if enable:
             args += ('--enable=' + ','.join(enable),)
 
-        return args + (filename,)
+        return args + files

--- a/tests/c_languages/CPPCheckBearTest.py
+++ b/tests/c_languages/CPPCheckBearTest.py
@@ -1,9 +1,9 @@
 import os
+import unittest
 from queue import Queue
 
 from bears.c_languages.CPPCheckBear import CPPCheckBear
 from coalib.testing.BearTestHelper import generate_skip_decorator
-from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 
@@ -14,22 +14,35 @@ def get_absolute_test_path(file):
 
 
 @generate_skip_decorator(CPPCheckBear)
-class CPPCheckBearTest(LocalBearTestHelper):
+class CPPCheckBearTest(unittest.TestCase):
 
     def setUp(self):
         self.section = Section('cppcheck')
-        self.uut = CPPCheckBear(self.section, Queue())
-        self.good_file = get_absolute_test_path('good_file.cpp')
-        self.bad_file = get_absolute_test_path('bad_file.cpp')
-        self.warn_file = get_absolute_test_path('warn_file.cpp')
+        self.file_dict = {}
+        self.queue = Queue()
+        self.test_files = ['good_file.cpp', 'bad_file.cpp', 'warn_file.cpp']
 
-    def test_default(self):
-        self.check_validity(self.uut, [], self.good_file)
-        self.check_invalidity(self.uut, [], self.bad_file)
-        self.check_validity(self.uut, [], self.warn_file)
+    def get_results(self, files_to_check):
+        files = [get_absolute_test_path(file) for file in files_to_check]
+        for filename in files:
+            with open(filename, 'r', encoding='utf-8') as content:
+                self.file_dict[filename] = tuple(content.readlines())
+        self.uut = CPPCheckBear(self.file_dict,
+                                self.section,
+                                self.queue)
+        return list(self.uut.run_bear_from_section([], {}))
 
-    def test_enable(self):
+    def test_results_complete(self):
         self.section.append(Setting('enable', 'unusedFunction'))
-        self.check_validity(self.uut, [], self.good_file)
-        self.check_invalidity(self.uut, [], self.bad_file)
-        self.check_invalidity(self.uut, [], self.warn_file)
+        results = self.get_results(self.test_files)
+        messages = [result.message for result in results]
+        self.assertEqual(len(messages), 2)
+        self.assertRegex(messages[0], 'Array .+ out of bounds')
+        self.assertRegex(messages[1], "function 'f1' .+ never used")
+
+    def test_no_enable_entered(self):
+        results = self.get_results(self.test_files)
+        messages = [result.message for result in results]
+        self.assertEqual(len(messages), 1)
+        self.assertRegex(messages[0], 'Array .+ out of bounds')
+        self.assertNotRegex(messages[0], 'function .+ never used')

--- a/tests/c_languages/cppcheck_test_files/bad_file.cpp
+++ b/tests/c_languages/cppcheck_test_files/bad_file.cpp
@@ -1,0 +1,8 @@
+#define f(c) { \
+    char s[10]; \
+    s[c] = 42; \
+}
+int main() {
+    f(100);
+    return 0;
+}

--- a/tests/c_languages/cppcheck_test_files/good_file.cpp
+++ b/tests/c_languages/cppcheck_test_files/good_file.cpp
@@ -1,0 +1,5 @@
+using namespace std;
+int main() {
+    cout << "Hello, world!" << endl;
+    return 0;
+}

--- a/tests/c_languages/cppcheck_test_files/warn_file.cpp
+++ b/tests/c_languages/cppcheck_test_files/warn_file.cpp
@@ -1,0 +1,6 @@
+void f1(struct fred_t *p)
+{
+    int x;
+    if (p)
+        do_something(x);
+}


### PR DESCRIPTION
It solves the following problem #2078 
>Let's say I have a function f, defined in f.cpp and used in g.cpp. If I run cppcheck just on f.cpp, it will tell me [f.cpp:1]: (style) The function 'f' is never used.. If I run cppcheck on the whole directory, that message disappears, because it seems that the function is being used after all. However, in coala, these messages also appear, because, presumably, coala runs cppcheck on each individual file. Can I tell it to run on the whole directory?