### PR TITLE
JSONFormatBear.py: Try to fix float format

### DIFF
--- a/bears/js/JSONFormatBear.py
+++ b/bears/js/JSONFormatBear.py
@@ -11,6 +11,43 @@ from coalib.results.Diff import Diff
 from coalib.results.Result import Result
 
 
+class FloatWrapper():
+    """
+    Wrapper for floats, which allows you to keep float representation
+    from initial file.
+    """
+
+    def __init__(self, s):
+        self.s = s
+
+    def __repr__(self):
+        return self.s
+
+    def get_s(self):
+        return self.s
+
+
+def create_float_wrapper(obj):
+    """
+    Wraps obj by FloatWrapper.
+
+    :param obj:
+        Float from initial json file.
+    """
+    return FloatWrapper(obj)
+
+
+def default_floats(obj):
+    """
+    Handler for FloatWrapper objects, which return float from the initial file.
+
+    :param obj:
+        FloatWrapper object.
+    """
+    if isinstance(obj, FloatWrapper):
+        return obj.get_s()
+
+
 class JSONFormatBear(LocalBear):
 
     LANGUAGES = {'JSON'}
@@ -43,7 +80,8 @@ class JSONFormatBear(LocalBear):
 
         try:
             json_content = json.loads(''.join(file),
-                                      object_pairs_hook=OrderedDict)
+                                      object_pairs_hook=OrderedDict,
+                                      parse_float=create_float_wrapper)
         except JSONDecodeError as err:
             err_content = match(r'(.*): line (\d+) column (\d+)', str(err))
             yield Result.from_values(
@@ -58,7 +96,8 @@ class JSONFormatBear(LocalBear):
         corrected = json.dumps(json_content,
                                sort_keys=json_sort,
                                indent=indent_size,
-                               ensure_ascii=escape_unicode
+                               ensure_ascii=escape_unicode,
+                               default=default_floats
                                ).splitlines(True)
         # Because of a bug in several python versions we have to correct
         # whitespace here.

--- a/tests/js/JSONFormatBearTest.py
+++ b/tests/js/JSONFormatBearTest.py
@@ -6,6 +6,9 @@ from coalib.testing.LocalBearTestHelper import (verify_local_bear,
 from coalib.results.Result import Result
 from coalib.settings.Section import Section
 
+test_file = """{
+}"""
+
 
 test_file1 = """{
     "a": 5,
@@ -33,6 +36,34 @@ unicode_file = """{
 test_file4 = """{
     a: 5
 }"""
+
+
+test_file5 = """{
+    "expansion-coefficient": 23.4e-06,
+    "length": 3.2e-3
+}"""
+
+
+test_file6 = """{
+    "expansion-coefficient": 2.34e-05,
+    "length": 0.0032
+}"""
+
+
+test_file7 = """[
+    {
+        "quantity": 261,
+        "something": 23.4e-06,
+    },
+    {
+        "quantity": 292,
+        "something": 3.2e-3,
+    },
+    {
+        "quantity": 211,
+        "something": 23.4e-03,
+    }
+]"""
 
 
 class JSONTest(LocalBearTestHelper):
@@ -91,3 +122,11 @@ JSONFormatBearUnicodeTest = verify_local_bear(JSONFormatBear,
                                               invalid_files=(),
                                               settings={'escape_unicode':
                                                         'false'})
+
+JSONFormatBearFloatsTest = verify_local_bear(JSONFormatBear,
+                                             valid_files=(test_file5,
+                                                          test_file6,
+                                                          test_file7),
+                                             invalid_files=(),
+                                             settings={'escape_unicode':
+                                                       'false'})


### PR DESCRIPTION
I made PR as requested in the issue. Some hints will be appreciated.
Tries to fix float representation by wrapping it in objects and keeping
them as strings. Then reads the string from this object and serializes
it in json file. However, float saved as string and each attempt
convert it to float results in missing the initial format of that
float.

Fixes https://github.com/coala/coala-bears/issues/2062

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
