### PR TITLE
HTMLLintBear: Upgrade `html-linter`

### DIFF
--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -11,7 +11,7 @@ dennis~=0.9
 docutils-ast-writer~=0.1.2
 eradicate~=0.1.6
 guess-language-spirit~=0.5.2
-html-linter~=0.3.0
+html-linter~=0.4.0
 isort~=4.2
 language-check~=1.0
 lxml==3.6.0

--- a/bears/hypertext/HTMLLintBear.py
+++ b/bears/hypertext/HTMLLintBear.py
@@ -20,7 +20,7 @@ class HTMLLintBear:
     _html_lint = which('html_lint.py')
 
     LANGUAGES = {'HTML', 'Jinja2', 'PHP'}
-    REQUIREMENTS = {PipRequirement('html-linter', '0.3.0')}
+    REQUIREMENTS = {PipRequirement('html-linter', '0.4.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'


### PR DESCRIPTION
HTMLLintBear.py: Update to `html-linter 0.4.0`
from version `html-linter 0.3.0`.
This commit also changes to `html-linter 0.4.0` version in `bear-requirements.txt`.

Closes https://github.com/coala/coala-bears/issues/2004

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
