### PR TITLE
PHPCodeSnifferBear: Disable two kinds of error

### DIFF
--- a/bears/php/PHPCodeSnifferBear.py
+++ b/bears/php/PHPCodeSnifferBear.py
@@ -129,6 +129,7 @@ class PHPCodeSnifferBear:
  <rule ref="Generic.Files.LineLength">
   <properties>
    <property name="lineLimit" value="{max_line_length}"/>
+   <property name="absoluteLineLimit" value="{absolute_line_length}"/>
   </properties>
  </rule>
  <rule ref="Generic.Files.LineEndings">
@@ -162,6 +163,7 @@ class PHPCodeSnifferBear:
  </rule>
 </ruleset>
 '''.format(max_line_length=max_line_length,
+           absolute_line_length=0,
            line_ending_character=line_ending_character,
            indent_size=indent_size,
            some_rules=rules,

--- a/tests/php/PHPCodeSnifferBearTest.py
+++ b/tests/php/PHPCodeSnifferBearTest.py
@@ -38,9 +38,33 @@ $var = TRUE;
 $var = FALSE;
 """
 
+long_length_test_file = """<?php
+/**
+ * PHP_CodeSniffer tokenizes PHP code and detects violations of a defined set \
+of coding.This is to test that the absoluteLineLength is violated or not.
+
+ * PHP version 5
+ *
+ * @category PHP
+ * @package  Your_Package
+ * @author   John Snow <johnsnow@link.net>
+ * @license  https://licence.txt LICENSE
+ * @link     http://somelink
+ */
+>
+"""
+
 
 PHPCodeSnifferBearTest = verify_local_bear(
     PHPCodeSnifferBear,
     valid_files=(good_file,),
     invalid_files=(bad_file,),
+    tempfile_kwargs={'suffix': '.php'})
+
+
+PHPCodeSnifferBearLineLengthTest = verify_local_bear(
+    PHPCodeSnifferBear,
+    valid_files=(long_length_test_file,),
+    invalid_files=(),
+    settings={'max_line_length': '160'},
     tempfile_kwargs={'suffix': '.php'})


### PR DESCRIPTION
Adds and sets `absolute_line_length` to '0'.So as to disable two kinds
of errors.

Closes https://github.com/coala/coala-bears/issues/1950

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
