### PR TITLE
DocumentationStyleBear: changed docstring format

### DIFF
--- a/bears/documentation/DocumentationStyleBear.py
+++ b/bears/documentation/DocumentationStyleBear.py
@@ -141,16 +141,21 @@ class DocumentationStyleBear(DocBaseClass, LocalBear):
                 also 4 space indent
                 following lines are also 4 space indented
 
-        :param language: The programming language of the file(s).
-        :param docstyle: The docstyle to use. For example ``default`` or
-                         ``doxygen``. Docstyles are language dependent, meaning
-                         not every language is supported by a certain docstyle.
-        :param allow_missing_func_desc: When set ``True`` this will allow
-                         functions with missing descriptions, allowing
-                         functions to start with params.
-        :param indent_size: Number of spaces per indentation level.
-        :param expand_one_liners: When set ``True`` this will expand one liner
-                         docstrings.
+        :param language:
+            The programming language of the file(s).
+        :param docstyle:
+            The docstyle to use. For example ``default`` or
+            ``doxygen``. Docstyles are language dependent, meaning
+            not every language is supported by a certain docstyle.
+        :param allow_missing_func_desc:
+            When set ``True`` this will allow
+            functions with missing descriptions, allowing
+            functions to start with params.
+        :param indent_size:
+            Number of spaces per indentation level.
+        :param expand_one_liners:
+            When set ``True`` this will expand one liner
+            docstrings.
         """
 
         for doc_comment in self.extract(file, language, docstyle):


### PR DESCRIPTION
Since the parameters were specified incorrectly
in DocumentationStyleBear.py, they were changed
to implement correct indentation.

Fixes https://github.com/coala/coala-bears/issues/1941

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
