### PR TITLE
SpaceConsistencyBear: Add blanklines_at_EOF option

### DIFF
--- a/.ci/package.json.jinja2
+++ b/.ci/package.json.jinja2
@@ -3,4 +3,3 @@
   "version": "{{version}}",
   "dependencies": {{dependencies | jsonify(indent=4, sort_keys=True)}}
 }
-

--- a/tests/general/SpaceConsistencyBearTest.py
+++ b/tests/general/SpaceConsistencyBearTest.py
@@ -3,6 +3,8 @@ from queue import Queue
 from bears.general.SpaceConsistencyBear import (
     SpaceConsistencyBear, SpacingHelper)
 from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
+from coalib.results.Result import Result
+from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 from coalib.settings.Section import Section
 from coalib.settings.Setting import Setting
 
@@ -44,15 +46,18 @@ class SpaceConsistencyBearTest(LocalBearTestHelper):
         self.section.append(Setting('use_spaces', 'false'))
         self.section.append(Setting('allow_trailing_whitespace', 'true'))
         self.section.append(Setting('enforce_newline_at_EOF', 'false'))
+        self.section.append(Setting('allow_trailing_blanklines', 'false'))
 
         self.check_invalidity(self.uut, ['    t'])
         self.check_validity(self.uut, ['t \n'])
         self.check_validity(self.uut, ['\tt\n'])
+        self.check_validity(self.uut, [])
 
     def test_enforce_newline_at_eof(self):
         self.section.append(Setting('use_spaces', 'true'))
         self.section.append(Setting('allow_trailing_whitespace', 'true'))
         self.section.append(Setting('enforce_newline_at_EOF', 'true'))
+        self.section.append(Setting('allow_trailing_blanklines', 'true'))
 
         self.check_validity(self.uut,
                             ['hello world  \n'],
@@ -60,7 +65,9 @@ class SpaceConsistencyBearTest(LocalBearTestHelper):
         self.check_validity(self.uut,
                             ['def somecode():\n',
                              "    print('funny')\n",
-                             "    print('funny end.')\n"],
+                             "    print('funny end.')\n",
+                             '  \n',
+                             '\n'],
                             force_linebreaks=False)
         self.check_invalidity(self.uut,
                               [' no hello world'],
@@ -70,3 +77,35 @@ class SpaceConsistencyBearTest(LocalBearTestHelper):
                                "    print('funny')\n",
                                "    print('the result is not funny...')"],
                               force_linebreaks=False)
+
+    def test_trailing_blanklines(self):
+
+        self.maxDiff = None
+        self.section['use_spaces'] = 'true'
+        self.section['allow_trailing_whitespace'] = 'false'
+        self.section['enforce_newline_at_EOF'] = 'true'
+        self.section['allow_trailing_blanklines'] = 'false'
+        self.check_results(self.uut,
+                           ['  \n'],
+                           [Result.from_values('SpaceConsistencyBear',
+                                               'Trailing blanklines found.',
+                                               file='xyz.py',
+                                               line=1,
+                                               column=1,
+                                               end_line=1,
+                                               end_column=3)],
+                           filename = 'xyz.py')
+#        self.check_results(self.uut,
+#                           ['  \n',
+#                            '     \n',
+#                            '\n'],
+#                           [Result.from_values('SpaceConsistencyBear',
+#                                               'Trailing blanklines found.',
+#                                               file='xyz.py',
+#                                               line=1,
+#                                               column=1,
+#                                               end_line=3,
+#                                               end_column=1,
+#                                               severity=RESULT_SEVERITY.NORMAL
+#                                               )],
+#                           filename='xyz.py')


### PR DESCRIPTION
Add allow_trailing_blanklines option for whether to allow
trailing blanklines at EOF.

Closes https://github.com/coala/coala-bears/issues/1793

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
