### PR TITLE
.travis.yml: Move unsupported check to a script

### DIFF
--- a/.ci/check_unsupported.sh
+++ b/.ci/check_unsupported.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Non-zero exit code is what we want to check
+set +e
+
+# Enable capturing the non-zero exit status of setup.py instead of tee
+set -o pipefail
+
+set -x
+
+# mypy-lang and guess-language-spirit do not install on unsupported versions
+sed -i.bak -E '/^(mypy-lang|guess-language-spirit)/d' bear-requirements.txt
+
+python setup.py install | tee setup.log
+
+retval=$?
+
+set +x
+
+# coalib.__init__.py should exit with 4 on unsupported versions of Python
+# And setup.py emits something else.
+if [[ $retval == 0 ]]; then
+  echo "Unexpected error code 0"
+  exit 1
+else
+  echo "setup.py error code $retval ok"
+fi
+
+# error when no lines selected by grep
+set -e
+
+grep -q 'coala supports only python 3.4 or later' setup.log
+
+echo "Unsupported check completed successfully"

--- a/.ci/deps.coala-bears.sh
+++ b/.ci/deps.coala-bears.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -x
 set -e
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,19 @@ python:
 matrix:
   include:
     - python: 2.7
-      env: UNSUPPORTED=true
+      env: UNSUPPORTED=true PIP_NO_COMPILE=1
+      addons: false
+      before_install: true
+      install: pip install 3to2
+      before_script: true
+      script: .ci/check_unsupported.sh
     - python: 3.3
-      env: UNSUPPORTED=true
+      env: UNSUPPORTED=true PIP_NO_COMPILE=1
+      addons: false
+      before_install: true
+      install: true
+      before_script: true
+      script: .ci/check_unsupported.sh
 
 dist: trusty
 
@@ -93,32 +103,12 @@ before_install:
     cat test-requirements.txt docs-requirements.txt
     bear-requirements.txt >> requirements.txt
   - sed -i '/^-r/d' requirements.txt
-  # On unsupported versions, coala will be installed in the `script` block
-  # mypy-lang does not install, and 3to2 must be pre-installed
-  # https://bitbucket.org/spirit/guess_language/issues/18
-  - >
-    if [[ "$UNSUPPORTED" == true ]]; then
-      pip install 3to2
-      export PIP_NO_COMPILE=1
-      sed -i.bak '/^coala/d' requirements.txt
-      sed -i.bak '/^mypy-lang/d' requirements.txt bear-requirements.txt
-    fi
 
 before_script:
   - mv requirements.orig requirements.txt
-  - if [[ "$UNSUPPORTED" != true ]]; then bash .ci/deps.coala-bears.sh; fi
+  - .ci/deps.coala-bears.sh
 
 script:
-  - >
-    if [[ "$UNSUPPORTED" == true ]]; then
-      set -e
-      python setup.py install --no-compile | tee setup.err
-      grep -q 'coala supports only python 3.4 or later' setup.err
-      if grep -q 'Traceback (most recent call last)' setup.err; then
-        false
-      fi
-    fi
-  - if [[ "$UNSUPPORTED" == true ]]; then exit; fi
   - python setup.py bdist_wheel
   - pip install $(ls ./dist/*.whl)"[alldeps]"
   - bash .ci/tests.sh


### PR DESCRIPTION
The unsupported check was previously a hack inside the main
Travis CI `script` block, requiring many workarounds
throughout the .travis.yml.
Travis CI now supports custom `script` blocks for each build
matrix entry, which allows the logic to be moved to an
external and more clear script.
In addition, all of the installation steps have been
removed, making these jobs much faster to complete.

Closes https://github.com/coala/coala-bears/issues/2182

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
