### PR TITLE
WIP: GitCommitBear.py: Enforce single newline

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -118,6 +118,10 @@ class GitCommitBear(GlobalBear):
         shortlog = stdout[:pos] if pos != -1 else stdout
         body = stdout[pos+1:] if pos != -1 else ''
 
+        if pos != -1 and body[1] is '\n':
+            yield Result(self, 'More than one newline between'
+                                ' shortlog and body')
+
         if len(stdout) == 0:
             if not allow_empty_commit_message:
                 yield Result(self, 'HEAD commit has no message.')

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -288,6 +288,13 @@ class GitCommitBearTest(unittest.TestCase):
                              body_regex=r'TICKER\s*CLOSE\s+[1-9][0-9]*'), [])
         self.assert_no_msgs()
 
+    def test_extra_newlines_between_shortlog_and_body(self):
+        commit = 'Shortlog\n\n\nBody\n\nCloses #1010101'
+        self.git_commit(commit)
+        print(self.run_uut())
+        self.assertEqual(self.run_uut(),
+                         ['More than one newline between shortlog and body'])
+
     def test_check_issue_reference(self):
         # Commit with no remotes configured
         self.git_commit('Shortlog\n\n'


### PR DESCRIPTION
Add check for single newline between
shortlog and body of commit message.

Closes https://github.com/coala/coala-bears/issues/1351

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
