### PR TITLE
HTMLLintBear.py: Update `html-linter`

### DIFF
--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -11,7 +11,7 @@ dennis~=0.9
 docutils-ast-writer~=0.1.2
 eradicate~=0.1.6
 guess-language-spirit~=0.5.2
-html-linter~=0.3.0
+html-linter~=0.4.0
 isort~=4.2
 language-check~=1.0
 lxml==3.6.0

--- a/bears/hypertext/HTMLLintBear.py
+++ b/bears/hypertext/HTMLLintBear.py
@@ -20,7 +20,7 @@ class HTMLLintBear:
     _html_lint = which('html_lint.py')
 
     LANGUAGES = {'HTML', 'Jinja2', 'PHP'}
-    REQUIREMENTS = {PipRequirement('html-linter', '0.3.0')}
+    REQUIREMENTS = {PipRequirement('html-linter', '0.4.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'


### PR DESCRIPTION
Update `html-linter` from version `0.3.0` to `0.4.0`.

Closes https://github.com/coala/coala-bears/issues/2004