### PR TITLE
docs-requirements: build break

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,2 +1,2 @@
-sphinx~=1.6.2
+sphinx>=1.6.2,<1.6.6
 sphinx_rtd_theme~=0.2.4


### PR DESCRIPTION
Change the doc-requirements to build the
circle-ci break.

Fixes https://github.com/coala/coala-bears/issues/2223

EDIT by @Makman2:
Closes --> Fixes (so it's consistent with the commit)