### PR TITLE
Change the version of jshint from 2 to 2.9.5

### DIFF
--- a/bears/js/JSHintBear.py
+++ b/bears/js/JSHintBear.py
@@ -35,7 +35,7 @@ class JSHintBear:
     """
 
     LANGUAGES = {'JavaScript'}
-    REQUIREMENTS = {NpmRequirement('jshint', '2')}
+    REQUIREMENTS = {NpmRequirement('jshint', '2.9.5')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "eslint-plugin-import": "~2",
     "happiness": "~10",
     "htmlhint": "~0.9.13",
-    "jshint": "~2",
+    "jshint": "~2.9.5",
     "postcss-cli": "~2",
     "pug-lint": "~2.4.0",
     "ramllint": ">=1.2.2 <1.2.4 || >=1.2.5 <1.3.0",


### PR DESCRIPTION
bears/js/JSHintBear.py: Change '2' to '2.9.5' JSHint
package.json: Change '2' to '2.9.5' JSHint

The edition ensures that the latest JSHint version 2.9.5 is used in the
JSHintBear.

Closes https://github.com/coala/coala-bears/issues/2216

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
