### PR TITLE
circle.yml : Add script to kill developer builds

### DIFF
--- a/.ci/buildci.sh
+++ b/.ci/buildci.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# this script check for 'Circle' in the commit message
+
+MESSAGE=$(git log -1 HEAD --pretty=format:%s)
+
+if [[ "$MESSAGE" == *Circle* ]]; then
+    exit 0
+fi
+
+exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -54,6 +54,15 @@ machine:
   java:
     version: oraclejdk8
 
+jobs:
+  build:
+    branches:
+      only:
+        - master
+        - coala/*
+    command:
+      - bash .ci/buildci.sh
+
 test:
   override:
     - python setup.py bdist_wheel:


### PR DESCRIPTION
This ensures that circle will be used on PRs,
branch master and those matching regex coala/* 
The added script checks for 'Circle' in the commit message and returns exit status
based on which the build is killed or not

Closes https://github.com/coala/coala-bears/issues/1946