### PR TITLE
DocumentationStyleBear: Add use_spaces param

### DIFF
--- a/bears/documentation/DocumentationStyleBear.py
+++ b/bears/documentation/DocumentationStyleBear.py
@@ -24,7 +24,8 @@ class DocumentationStyleBear(DocBaseClass, LocalBear):
                               doc_comment: DocumentationComment,
                               allow_missing_func_desc: str=False,
                               indent_size: int=4,
-                              expand_one_liners: str=False):
+                              expand_one_liners: str=False,
+                              use_spaces: bool=True):
         """
         This fixes the parsed documentation comment.
 
@@ -37,6 +38,8 @@ class DocumentationStyleBear(DocBaseClass, LocalBear):
             Number of spaces per indentation level.
         :param expand_one_liners:
             When set ``True`` this will expand one liner docstrings.
+        :param use_spaces:
+            Decides whether spaces are used for indentation or tabs.
         :return:
             An instance of a processed/fixed DocumentationComment.
         """
@@ -82,9 +85,9 @@ class DocumentationStyleBear(DocBaseClass, LocalBear):
                 if stripped_desc[0] != '':
                     stripped_desc.insert(0, '')
 
-            # Indent with 4 spaces.
-            stripped_desc = ('' if line == '' else ' ' * indent_size
-                             + line for line in stripped_desc)
+            indent = ' ' if use_spaces else '\t'
+            stripped_desc = ('' if line == '' else indent * indent_size +
+                             line for line in stripped_desc)
 
             new_desc = '\n'.join(stripped_desc)
 
@@ -126,7 +129,8 @@ class DocumentationStyleBear(DocBaseClass, LocalBear):
 
     def run(self, filename, file, language: str,
             docstyle: str='default', allow_missing_func_desc: str=False,
-            indent_size: int=4, expand_one_liners: str=False):
+            indent_size: int=4, expand_one_liners: str=False,
+            use_spaces: bool=True):
         """
         Checks for certain in-code documentation styles.
 
@@ -156,6 +160,8 @@ class DocumentationStyleBear(DocBaseClass, LocalBear):
         :param expand_one_liners:
             When set ``True`` this will expand one liner
             docstrings.
+        :param use_spaces:
+            Decides whether spaces are used for indentation or tabs.
         """
 
         for doc_comment in self.extract(file, language, docstyle):
@@ -168,7 +174,7 @@ class DocumentationStyleBear(DocBaseClass, LocalBear):
             else:
                 (new_comment, warning_desc) = self.process_documentation(
                                 doc_comment, allow_missing_func_desc,
-                                indent_size, expand_one_liners)
+                                indent_size, expand_one_liners, use_spaces)
 
                 # Cache cleared so a fresh docstring is assembled
                 doc_comment.assemble.cache_clear()

--- a/tests/documentation/DocumentationStyleBearTest.py
+++ b/tests/documentation/DocumentationStyleBearTest.py
@@ -60,10 +60,46 @@ def test_MalformedComment(test_data, message, optional_setting=None):
                 DocumentationStyleBear(section, Queue()),
                 'dummy_file',
                 test_data,
+                use_spaces=True,
+                **arguments) as results:
+            self.assertEqual(results[0].message, message)
+
+        with execute_bear(
+                DocumentationStyleBear(section, Queue()),
+                'dummy_file',
+                test_data,
+                use_spaces=False,
                 **arguments) as results:
             self.assertEqual(results[0].message, message)
 
     return test_MalformedComment_function
+
+
+def test_use_spaces(test_data, message, optional_setting=None):
+    def test_use_spaces_function(self):
+        arguments = {'language': 'python', 'docstyle': 'default'}
+        if optional_setting:
+            arguments.update(optional_setting)
+        section = Section('test-section')
+        for key, value in arguments.items():
+            section[key] = value
+
+        with execute_bear(
+                DocumentationStyleBear(section, Queue()),
+                'dummy_file',
+                test_data,
+                **arguments) as results:
+            self.assertEqual(results[0].message, message)
+
+        with execute_bear(
+                DocumentationStyleBear(section, Queue()),
+                'dummy_file',
+                test_data,
+                use_spaces=False,
+                **arguments) as results:
+            self.assertEqual(results[0].message, message)
+
+    return test_use_spaces_function
 
 
 class DocumentationStyleBearTest(unittest.TestCase):
@@ -97,3 +133,13 @@ class DocumentationStyleBearTest(unittest.TestCase):
              marker has been found, but no instance of DocComment is
              returned."""),
         {'language': 'java'})
+
+    test_use_spaces_comment = test_use_spaces(
+        ['"""\n',
+         ':param a:'
+         '    Is just a param'
+         '"""'],
+        dedent("""\
+             Missing function description.
+             Please set allow_missing_func_desc = True to ignore this warning.
+             """))


### PR DESCRIPTION
Add use_spaces param in DocumentationStyleBear.

Closes https://github.com/coala/coala-bears/issues/1834

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `cobot mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
