### PR TITLE
Jinja2Bear: Add support for whitespace control

### DIFF
--- a/bears/jinja2/Jinja2Bear.py
+++ b/bears/jinja2/Jinja2Bear.py
@@ -112,11 +112,17 @@ class Jinja2Bear(LocalBear):
 
     VARIABLE_REGEX = re.compile(
         r'(?P<open>{{)(?P<content>.*?)(?P<close>}})')
+    STATEMENT_REGEX = re.compile(
+        r'(?P<open>{%[+-]?)'
+        r'(?P<content>(?![+-]?\s*for)'
+        r'(?![+-]?\s*if)(?![+-]?\s*endfor)'
+        r'(?![+-]?\s*endif).*?)'
+        r'(?P<close>[+-]?%})')
     CONTROL_START_REGEX = re.compile(
-        r'(?P<open>{%)(?P<content>\s*(for|if).*?)(?P<close>%})')
+        r'(?P<open>{%[+-]?)(?P<content>\s*(for|if).*?)(?P<close>[+-]?%})')
     CONTROL_END_REGEX = re.compile(
-        r'(?P<open>{%)(?P<content>\s*end(for|if)\s*?)'
-        r'(?P<close>%})(?P<label>{#.*?#})?')
+        r'(?P<open>{%[+-]?)(?P<content>\s*end(for|if)\s*?)'
+        r'(?P<close>[+-]?%})(?P<label>{#.*?#})?')
 
     def handle_control_spacing_issue(self, file, filename, line, line_number,
                                      control_spacing, match_object):
@@ -182,6 +188,44 @@ class Jinja2Bear(LocalBear):
                     column=m.start(0) + 1,
                     end_line=line_number,
                     end_column=m.end(0) + 1,
+                    diffs=diff)
+
+    def check_for_statement_spacing_issues(self,
+                                           file,
+                                           filename,
+                                           line,
+                                           line_number,
+                                           statement_spacing):
+        """
+        Checks any statement in the given line for spacing issues.
+
+        :param file:
+            The content of the file currently being inspected.
+        :param filename:
+            The name of the file currently being inspected.
+        :param line:
+            The content of the line currently being inspected.
+        :param line_number:
+            The current line number.
+        :param statement_spacing:
+            The number of spaces required on each side of a statement tag.
+        """
+        for match in self.STATEMENT_REGEX.finditer(line):
+            content = match.group('content')
+            if not has_required_spacing(content, statement_spacing):
+                diff = generate_spacing_diff(
+                    file, filename, line, line_number, match,
+                    statement_spacing)
+                yield Result.from_values(
+                    origin=self,
+                    message='Statement block not spaced with '
+                            '{} spaces on each side.'.format(
+                                statement_spacing),
+                    file=filename,
+                    line=line_number,
+                    column=match.start() + 1,
+                    end_line=line_number,
+                    end_column=match.end() + 1,
                     diffs=diff)
 
     def check_control_start_tags(self,
@@ -310,6 +354,7 @@ class Jinja2Bear(LocalBear):
             filename,
             file,
             variable_spacing: int=1,
+            statement_spacing: int=1,
             control_spacing: int=1):
         """
         Check `Jinja2 templates <http://jinja.pocoo.org>`_ for syntax,
@@ -321,6 +366,10 @@ class Jinja2Bear(LocalBear):
             this: ``{{ var_name }}``. This can be set to any number of spaces
             via the setting ``variable_spacing``.
             Malformatted variable tags are detected and fixes suggested.
+        * Statement spacing:
+            Statement tags should be padded with one space on each side, like
+            this: ``{% statement %}``. This can be set to any number of spaces
+            via the setting ``statement_spacing``.
         * Control spacing:
             Like variable spacing, but for control blocks, i.e. ``if`` and
             ``for`` constructs. Looks at both start and end block.
@@ -345,6 +394,9 @@ class Jinja2Bear(LocalBear):
         :param variable_spacing:
             The number of spaces a variable block should be spaced with.
             Default is 1.
+        :param statement_spacing:
+            The number of spaces a statement block should be spaced with.
+            Default is 1.
         :param control_spacing:
             The number of spaces a control block should be spaced with.
             Default is 1.
@@ -359,6 +411,9 @@ class Jinja2Bear(LocalBear):
 
             yield from self.check_for_variable_spacing_issues(
                 file, filename, line, line_number, variable_spacing)
+
+            yield from self.check_for_statement_spacing_issues(
+                file, filename, line, line_number, statement_spacing)
 
             yield from self.check_control_start_tags(
                 file, filename, line, line_number, control_spacing)

--- a/tests/jinja2/Jinja2BearTest.py
+++ b/tests/jinja2/Jinja2BearTest.py
@@ -23,6 +23,41 @@ Jinja2BearCustomVariableSpacingTest = verify_local_bear(
                    r'{{  var }}'),
     settings={'variable_spacing': '0'})
 
+Jinja2BearStatementSpacingTest = verify_local_bear(
+    Jinja2Bear,
+    valid_files=(r'foo {% statement1 %} bar',
+                 r'foo {% statement2 foobar %} bar',
+                 r'foo {%+ statement3 %} bar',
+                 r'foo {%+ statement4 -%} bar',
+                 r'foo {% statement5 -%} bar',
+                 r'foo {%- statement1 +%} bar'),
+    invalid_files=(r'foo {%foo bar %} bar',
+                   r'foo {% foo bar%} bar',
+                   r'foo {%foo bar%} bar',
+                   r'foo {%   foo bar  %} bar',
+                   r'foo {%+   statement3     %} bar',
+                   r'foo {%+statement4    -%} bar',
+                   r'foo {%    statement5-%} bar',
+                   r'foo {%-  statement1    +%} bar'))
+
+Jinja2BearCustomStatementSpacingTest = verify_local_bear(
+    Jinja2Bear,
+    valid_files=(r'foo {%statement1%} bar',
+                 r'foo {%statement2 foobar%} bar',
+                 r'foo {%+statement3%} bar',
+                 r'foo {%+statement4-%} bar',
+                 r'foo {%statement5-%} bar',
+                 r'foo {%-statement1+%} bar'),
+    invalid_files=(r'foo {%foo bar %} bar',
+                   r'foo {% foo bar%} bar',
+                   r'foo {% foo bar %} bar',
+                   r'foo {%   foo bar  %} bar',
+                   r'foo {%+   statement3     %} bar',
+                   r'foo {%+statement4    -%} bar',
+                   r'foo {%    statement5-%} bar',
+                   r'foo {%-  statement1    +%} bar'),
+    settings={'statement_spacing': '0'})
+
 
 class Jinja2BearSpacingDiffTest(unittest.TestCase):
 
@@ -38,6 +73,16 @@ class Jinja2BearSpacingDiffTest(unittest.TestCase):
                              '@@ -1 +1 @@\n'
                              '-foo {{var }} bar\n'
                              '+foo {{ var }} bar')
+
+    def test_statement_spacing(self):
+        content = (r'foo {%-statement1 %} bar',)
+        with execute_bear(self.uut, 'F', content) as result:
+            self.assertEqual(result[0].diffs['F'].unified_diff,
+                             '--- \n'
+                             '+++ \n'
+                             '@@ -1 +1 @@\n'
+                             '-foo {%-statement1 %} bar\n'
+                             '+foo {%- statement1 %} bar')
 
     def test_control_spacing(self):
         content = [
@@ -58,17 +103,29 @@ class Jinja2BearSpacingDiffTest(unittest.TestCase):
 
 Jinja2BearControlSpacingTest = verify_local_bear(
     Jinja2Bear,
-    valid_files=(r'foo {% if something %} bar {% endif %}',),
+    valid_files=(r'foo {% if something %} bar {% endif %}',
+                 r'foo {%+ if something -%} bar {%+ endif -%}',
+                 r'foo {%- if something +%} bar {%- endif +%}',
+                 r'foo {%+ for x in y +%} foobar {%- endfor -%}'),
     invalid_files=(r'foo {% if var%} bar {% endif %}',
                    r'{% if something %} foo {%endif%}{# if something #}',
-                   r'{%for a in var %} {% endfor %}'))
+                   r'foo {%+if something    -%} bar {%+endif-%}',
+                   r'foo {%-   if something+%} bar {%-   endif    +%}',
+                   r'{%for a in var %} {% endfor %}',
+                   r'foo {%+for x in y+%} foobar {%-    endfor   -%}'))
 
 Jinja2BearCustomControlSpacingTest = verify_local_bear(
     Jinja2Bear,
-    valid_files=(r'foo {%if something%} bar {%endif%}',),
+    valid_files=(r'foo {%if something%} bar {%endif%}',
+                 r'foo {%+if something-%} bar {%+endif-%}',
+                 r'foo {%-if something+%} bar {%-endif+%}',
+                 r'foo {%+for x in y+%} foobar {%-endfor-%}'),
     invalid_files=(r'foo {% if var%} bar {%endif%}',
                    r'foo {%if foo%} bar {% endif%}',
-                   r'{%for a in var %} {%endfor%}'),
+                   r'foo {%+ if something -%} bar {%+  endif -%}',
+                   r'foo {%-   if something +%} bar {%-   endif    +%}',
+                   r'{%for a in var %} {%endfor%}',
+                   r'foo {%+ for x in y +%} foobar {%-    endfor   -%}'),
     settings={'control_spacing': '0'})
 
 
@@ -81,12 +138,12 @@ render stuff
 
 good_file2 = """
 foo
-{% if x == something %}
+{%+ if x == something -%}
 render stuff
-{% endif %}{# if x == something #}
+{%- endif +%}{# if x == something #}
 """
 
-good_file3 = '{% for x in y %} one liner needs no label {% endfor %}'
+good_file3 = '{%+ for x in y +%} one liner needs no label {%- endfor -%}'
 
 bad_file1 = """
 foo
@@ -97,9 +154,9 @@ render stuff
 
 bad_file2 = """
 foo
-{% if x == something %}
+{%+ if x == something -%}
 render stuff
-{% endif %}{# some random comment #} more stuff
+{%- endif +%}{# some random comment #} more stuff
 """
 
 Jinja2BearForLoopLabelTest = verify_local_bear(
@@ -137,10 +194,10 @@ class Jinja2BearLabelDiffTest(unittest.TestCase):
                 '+++ \n'
                 '@@ -2,4 +2,4 @@\n'
                 ' foo\n'
-                ' {% if x == something %}\n'
+                ' {%+ if x == something -%}\n'
                 ' render stuff\n'
-                '-{% endif %}{# some random comment #} more stuff\n'
-                '+{% endif %}{# if x == something #} more stuff\n')
+                '-{%- endif +%}{# some random comment #} more stuff\n'
+                '+{%- endif +%}{# if x == something #} more stuff\n')
 
 
 Jinja2BearControlBlockTest = verify_local_bear(


### PR DESCRIPTION
This adds support for whitespace control for
statement tags and when trim_blocks are used
with statement or control tags.

Closes https://github.com/coala/coala-bears/issues/2002