### PR TITLE
PycodestyleBearTest.py: Rename last LineLength test

### DIFF
--- a/tests/python/PycodestyleBearTest.py
+++ b/tests/python/PycodestyleBearTest.py
@@ -48,7 +48,7 @@ PycodestyleBearLineLengthTest = verify_local_bear(
     invalid_files=(long_line,)
 )
 
-PycodestyleBearLineLengthTest = verify_local_bear(
+PycodestyleBearLineLengthSettingTest = verify_local_bear(
     PycodestyleBear,
     valid_files=(long_line,),
     invalid_files=(),


### PR DESCRIPTION
Renamed the final test with a similar name to PycodestyleBearCustomLineLengthTest from PycodestyleBearLineLengthTest.