### PR TITLE
PycodestyleBear.py: Add ignore regex option

### DIFF
--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -1,3 +1,4 @@
+import re
 from coalib.bearlib.abstractions.Linter import linter
 from coalib.settings.Setting import typed_list
 
@@ -5,9 +6,8 @@ from dependency_management.requirements.PipRequirement import PipRequirement
 
 
 @linter(executable='pycodestyle',
-        output_format='regex',
-        output_regex=r'(?P<line>\d+) (?P<column>\d+) '
-                     r'(?P<message>(?P<origin>\S+).*)')
+        use_stdout=True,
+        use_stderr=False)
 class PycodestyleBear:
     """
     A wrapper for the tool ``pycodestyle`` formerly known as ``pep8``.
@@ -18,16 +18,32 @@ class PycodestyleBear:
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'
     CAN_DETECT = {'Formatting'}
+    output_regex = re.compile(r'(?P<line>\d+) (?P<column>\d+) '
+                              r'(?P<message>(?P<origin>\S+).*)')
 
-    @staticmethod
-    def create_arguments(
-            filename, file, config_file,
-            pycodestyle_ignore: typed_list(str)=(
-                'E121', 'E123', 'E126', 'E133', 'E226',
-                'E241', 'E242', 'E704', 'W503'
-            ),
-            pycodestyle_select: typed_list(str)=(),
-            max_line_length: int=79):
+    source_regex = (r'(?P<line>\d+) (?P<column>\d+) '
+                    r'(?P<message>(?P<origin>E501).*)'
+                    r'(?:\s)(?P<source>.*{0}.*)')
+
+    def process_output(self, output, filename, file):
+        stdout = output
+        for regex in self.ignore_regexes:
+            p = re.compile(self.source_regex.format(regex))
+            stdout = p.sub('', stdout)
+
+        return self.process_output_regex(
+            stdout, filename, file,
+            output_regex=self.output_regex)
+
+    def create_arguments(self,
+                         filename, file, config_file,
+                         pycodestyle_ignore: typed_list(str)=(
+                             'E121', 'E123', 'E126', 'E133', 'E226',
+                             'E241', 'E242', 'E704', 'W503'
+                         ),
+                         pycodestyle_select: typed_list(str)=(),
+                         max_line_length: int=79,
+                         ignore_regex: typed_list(str)=('https?://',)):
         """
         :param pycodestyle_ignore:
             Comma separated list of errors to ignore.
@@ -38,7 +54,12 @@ class PycodestyleBear:
             See ``pydocstyle`` documentation for a complete list of errors.
         :param max_line_length:
             Limit lines to this length.
+        :param ignore_regex:
+            Regex expressions that should be exception to E501 line too long
+            error.
         """
+        self.ignore_regexes = [regex for regex in ignore_regex]
+
         arguments = [r'--format=%(row)d %(col)d %(code)s %(text)s']
 
         if pycodestyle_ignore:
@@ -50,7 +71,7 @@ class PycodestyleBear:
             arguments.append('--select=' + select)
 
         arguments.append('--max-line-length=' + str(max_line_length))
-
+        arguments.append('--show-source')
         arguments.append(filename)
 
         return arguments

--- a/tests/python/PycodestyleBearTest.py
+++ b/tests/python/PycodestyleBearTest.py
@@ -54,3 +54,30 @@ PycodestyleBearLineLengthTest = verify_local_bear(
     invalid_files=(),
     settings={'max_line_length': 200}
 )
+
+bad_file_2 = '''
+x = "http://a.domain.de"
+
+
+
+
+y = 5
+'''
+
+PycodestyleBearIgnoreRegexTest = verify_local_bear(
+    PycodestyleBear,
+    valid_files=('x = "ftps://a.domain.de"',
+                 'x = "ftp://a.domain.de"',),
+    invalid_files=(bad_file_2,),
+    settings={'max_line_length': 5,
+              'ignore_regex': 'ftps?://'}
+)
+
+
+PycodestyleBearDefaultRegexTest = verify_local_bear(
+    PycodestyleBear,
+    valid_files=('x = "http://a.domain.de"',
+                 'x = "https://a.domain.de"',),
+    invalid_files=('y = "htttps"',),
+    settings={'max_line_length': 4}
+)


### PR DESCRIPTION
Add settings for ignoring certain regex expression while considering line length (E501 error rule).