### PR TITLE
bears/general: Use string.expandtabs()

### DIFF
--- a/bears/general/LineLengthBear.py
+++ b/bears/general/LineLengthBear.py
@@ -30,11 +30,10 @@ class LineLengthBear(LocalBear):
         :param ignore_length_regex: Lines matching each of the regular
                                     expressions in this list will be ignored.
         '''
-        spacing_helper = SpacingHelper(indent_size)
         ignore_regexes = [re.compile(regex) for regex in ignore_length_regex]
 
         for line_number, line in enumerate(file):
-            line = spacing_helper.replace_tabs_with_spaces(line)
+            line = line.expandtabs(indent_size)
             if len(line) > max_line_length + 1:
                 if any(regex.search(line) for regex in ignore_regexes):
                     continue

--- a/bears/general/SpaceConsistencyBear.py
+++ b/bears/general/SpaceConsistencyBear.py
@@ -66,8 +66,7 @@ class SpaceConsistencyBear(LocalBear):
 
             if use_spaces:
                 pre_replacement = replacement
-                replacement = spacing_helper.replace_tabs_with_spaces(
-                    replacement)
+                replacement = replacement.expandtabs(indent_size)
                 if replacement != pre_replacement:
                     result_texts.append('Tabs used instead of spaces.')
             else:


### PR DESCRIPTION
SpacingHelper.replace_tabs_with_spaces is a less efficient
implementation of string.expandtabs(), and should be deprecated.