### PR TITLE
PySafetyBear.py: Yield correct message template

### DIFF
--- a/bears/python/requirements/PySafetyBear.py
+++ b/bears/python/requirements/PySafetyBear.py
@@ -11,6 +11,16 @@ from coalib.results.SourceRange import SourceRange
 from coalib.settings.Setting import typed_list
 
 
+def cve_key_checker(vulnerability):
+    if 'cve' in vulnerability.data:
+        if vulnerability.data['cve'] is None:
+            return None
+        else:
+            return True
+    else:
+        return None
+
+
 # the safety module expects an object that looks like this
 # (not importing it from there because it's in a private-ish location)
 Package = namedtuple('Package', ('key', 'version'))
@@ -49,7 +59,7 @@ class PySafetyBear(LocalBear):
             return
 
         for vulnerability in safety.check(packages=packages):
-            if vulnerability.is_cve:
+            if cve_key_checker(vulnerability):
                 message_template = (
                     '{vuln.name}{vuln.spec} is vulnerable to {vuln.cve_id} '
                     'and your project is using {vuln.version}.'

--- a/tests/python/requirements/PySafetyBearTest.py
+++ b/tests/python/requirements/PySafetyBearTest.py
@@ -1,11 +1,44 @@
 from queue import Queue
 from unittest import mock
+import unittest
 
 from safety.safety import Vulnerability
 
-from bears.python.requirements.PySafetyBear import PySafetyBear, Package
+from bears.python.requirements.PySafetyBear import (
+    PySafetyBear,
+    Package,
+    cve_key_checker
+)
 from coalib.settings.Section import Section
 from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
+
+Vuln1 = Vulnerability(name='bottle', spec='<0.12.10',
+                      version='0.10.1',
+                      data={'cve': 'CVE-2016-9964',
+                            'id': 'pyup.io-25642',
+                            'advisory': 'redirect() in '
+                            'bottle.py in '
+                            'bottle 0.12.10 doesn\'t filter '
+                            'a "\\r\\n" sequence, which leads '
+                            'to a CRLF attack, as demonstrated '
+                            'by a redirect("233\\r\\nSet-Cookie: name=salt") '
+                            'call.',
+                            'v': '<0.12.10',
+                            'specs': ['<0.12.10']})
+
+Vuln2 = Vulnerability(name='locustio', spec='<0.7',
+                      version='0.5.1',
+                      data={'cve': None, 'id': 'pyup.io-25878',
+                            'advisory': 'locustio before 0.7 uses pickle.',
+                            'v': '<0.7',
+                            'specs': ['<0.7']})
+
+Vuln3 = Vulnerability(name='locustio', spec='<0.7',
+                      version='0.5.1',
+                      data={'id': 'pyup.io-25878',
+                            'advisory': 'locustio before 0.7 uses pickle.',
+                            'v': '<0.7',
+                            'specs': ['<0.7']})
 
 
 class PySafetyBearTest(LocalBearTestHelper):
@@ -60,3 +93,17 @@ class PySafetyBearTest(LocalBearTestHelper):
         ) as check:
             self.check_validity(self.uut, ['foo', 'bar>2'])
             assert not check.called
+
+
+class cveKeyCheckerFunctionTest(unittest.TestCase):
+    def test_cve_key_with_value(self):
+        myresult = cve_key_checker(Vuln1)
+        self.assertEqual(myresult, True)
+
+    def test_cve_key_without_value(self):
+        myresult = cve_key_checker(Vuln2)
+        self.assertEqual(myresult, None)
+
+    def test_without_cve_key(self):
+        myresult = cve_key_checker(Vuln3)
+        self.assertEqual(myresult, None)


### PR DESCRIPTION
PySafetyBear fails to yield the correct message,
as currenlty we are using 0.5.1 version of
``Safety`` and also live data format also changes,
so PySafetyBear ouputting wrong message template,
changes are done accordingly to prevent the
failing of test of  PySafetyBear and display
correct message template.

Closes: https://github.com/coala/coala-bears/issues/2293