### PR TITLE
GitCommitBear: Suppress excess output from nltk

### DIFF
--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -2,7 +2,9 @@ import nltk
 import re
 import shutil
 import os
+import logging
 from urllib.parse import urlparse
+from contextlib import redirect_stdout
 
 from coalib.bears.GlobalBear import GlobalBear
 from dependency_management.requirements.PipRequirement import PipRequirement
@@ -36,11 +38,15 @@ class GitCommitBear(GlobalBear):
     def setup_dependencies(self):
         if not self._nltk_data_downloaded and bool(
                 self.section.get('shortlog_imperative_check', True)):
-            nltk.download([
-                'punkt',
-                'averaged_perceptron_tagger',
-            ])
-            type(self)._nltk_data_downloaded = True
+            logger = logging.getLogger()
+            logger.write = lambda msg: logger.debug(
+                msg) if msg != '\n' else None
+            with redirect_stdout(logger):
+                nltk.download([
+                    'punkt',
+                    'averaged_perceptron_tagger'
+                ])
+                type(self)._nltk_data_downloaded = True
 
     @classmethod
     def check_prerequisites(cls):


### PR DESCRIPTION
Send output of nltk.download() from stdout to logger at
a debug level while executing GitCommitBear so that the excess
output is suppressed and only shown when explicitly asked for.

Fixes https://github.com/coala/coala-bears/issues/2374

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
