### PR TITLE
PycodestyleBear: Add default ignore W504

### DIFF
--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -26,7 +26,7 @@ class PycodestyleBear:
             filename, file, config_file,
             pycodestyle_ignore: typed_list(str)=(
                 'E121', 'E123', 'E126', 'E133', 'E226',
-                'E241', 'E242', 'E704', 'W503'
+                'E241', 'E242', 'E704', 'W503', 'W504',
             ),
             pycodestyle_select: typed_list(str)=(),
             max_line_length: int=79):


### PR DESCRIPTION
pycodestyle added W504 to the default ignore list.

Closes https://github.com/coala/coala-bears/issues/2428
