### PR TITLE
PySafetyBear: Add asciinema

### DIFF
--- a/bears/python/requirements/PySafetyBear.py
+++ b/bears/python/requirements/PySafetyBear.py
@@ -44,6 +44,7 @@ class PySafetyBear(LocalBear):
     AUTHORS_EMAILS = {'bence@underyx.me'}
     LICENSE = 'AGPL'
     CAN_DETECT = {'Security'}
+     ASCIINEMA_URL = 'https://asciinema.org/a/89021'
 
     def run(self, filename, file):
         """


### PR DESCRIPTION
Fixes #2371 
this is a WIP am still in the process of creating an asciinema for pySafetyBear as i have now to install linux to do that. I got a hiccup while doing the same with windows. On my Win10 machine It fails with ImportError: No module named termios.

Ill update this PR after installing linux, but if someone could help me create an asciinema and give me the number associated with it, that would be very helpful. thank you.