### PR TITLE
GitCommitBear: Ignore Github PR merge commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -161,12 +161,6 @@ script:
   # Ensure bear requirements are in sync with the bear PipRequirement
   - .ci/generate_bear_requirements.py
   - git diff --exit-code
-  # https://github.com/coala/coala-bears/issues/1037
-  - >
-    if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
-      sed -e '/bears = GitCommitBear/d' .coafile > .coafile.new
-      mv .coafile.new .coafile
-    fi
   - coala --non-interactive
   - codecov
   - python setup.py docs

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import re
 
 from bears.vcs.CommitBear import _CommitBear
 from coala_utils.ContextManagers import change_directory
@@ -24,4 +25,38 @@ class GitCommitBear(_CommitBear):
 
     def get_head_commit(self):
         with change_directory(self.get_config_dir() or os.getcwd()):
+            command = self.check_github_pull_request_temporary_merge_commit()
+            if command:
+                return run_shell_command(command)
+
             return run_shell_command('git log -1 --pretty=%B')
+
+    def check_github_pull_request_temporary_merge_commit(self):
+        """
+        This function creates a git command to fetch the
+        unmerged parent commit shortlog from a commit generated
+        by GitHub in a refs/pull/(\d+)/merge git remote reference.
+        Visit https://github.com/travis-ci/travis-ci/issues/8400
+        for more details.
+
+        :return: A git command (str) to fetch the unmerged parent
+                 commit if HEAD commit is a GitHub PR temporary
+                 merge commit, otherwise None"
+        """
+        stdout, _ = run_shell_command('git log -1 --pretty=%B')
+
+        pos = stdout.find('\n')
+        shortlog = stdout[:pos] if pos != -1 else stdout
+
+        github_pull_request_temporary_merge_commit_regex = re.compile(
+            r'^Merge ([0-9a-f]{40}) into ([0-9a-f]{40})$')
+        match = re.fullmatch(
+            github_pull_request_temporary_merge_commit_regex, shortlog)
+
+        if match:
+            unmerged_commit_sha = match.group(1)
+
+            command = ('git log -n 1 --pretty=%B ' +
+                       unmerged_commit_sha)
+
+            return command


### PR DESCRIPTION
This adds a check in GitCommitBear to identify
Github PR merge commits and ignore
all other tests for these commits.

Closes https://github.com/coala/coala-bears/issues/1037

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
