### PR TITLE
CISkipInspectBear.py: Bear to inspect commits that disable CI builds

### DIFF
--- a/bears/vcs/git/CISkipInspectBear.py
+++ b/bears/vcs/git/CISkipInspectBear.py
@@ -1,0 +1,64 @@
+import glob
+import re
+
+from bears.vcs.git.GitCommitMetadataBear import GitCommitMetadataBear
+from coalib.bears.GlobalBear import GlobalBear
+from coalib.results.Result import Result
+
+
+class CISkipInspectBear(GlobalBear):
+    LANGUAGES = {'Git'}
+    AUTHORS = {'The coala developers'}
+    AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
+    LICENSE = 'AGPL-3.0'
+
+    BEAR_DEPS = {GitCommitMetadataBear}
+
+    SKIP_CI_REGEX = r'\[ci skip\]|\[skip ci\]'
+
+    def run(self, dependency_results,
+            appveyor_ci: bool = False,
+            **kwargs):
+        """
+        Most CI allow commits to skip CI build by including sequences
+        like [skip ci] or [ci skip] anywhere in the commit message.
+        AppVeyor CI supports [skip appveyor] in addition to the above
+        but only in the commit title.
+        This bear checks the HEAD commit to see if it disables CI build
+        and return result accordingly. Supported CI include AppVeyor,
+        Bitrise, Circle CI, GitLab CI, Scrutinizer, Semaphore,
+        Shippable, Travis CI and wercker.
+
+        :param appveyor_ci:         Whether AppVeyor is used by the
+                                    project or not.
+        """
+        if appveyor_ci:
+            self.SKIP_CI_REGEX += r'|\[skip appveyor\]'
+
+        for result in dependency_results[GitCommitMetadataBear.name]:
+
+            if appveyor_ci:
+                pos = result.raw_commit_message.find('\n')
+                commit_title = result.raw_commit_message[:pos] if (
+                    pos != -1) else result.raw_commit_message
+
+            else:
+                commit_title = result.raw_commit_message
+
+            match = re.search(self.SKIP_CI_REGEX, commit_title)
+            if not match:
+                continue
+
+            all_files = (result.modified_files +
+                         result.added_files + result.deleted_files)
+
+            for file in all_files:
+                for pattern in self.section['files']:
+                    if file not in glob.glob(pattern):
+                        continue
+                    yield Result(
+                        self,
+                        'This commit modifies a file that has '
+                        'pattern of type "%s", thus should '
+                        'not disable CI build.' %
+                        pattern)

--- a/tests/vcs/git/CISkipInspectBearTest.py
+++ b/tests/vcs/git/CISkipInspectBearTest.py
@@ -1,0 +1,114 @@
+import os
+import platform
+import shutil
+import stat
+import unittest
+import unittest.mock
+from pathlib import Path
+from queue import Queue
+from tempfile import mkdtemp
+
+from bears.vcs.git.GitCommitMetadataBear import GitCommitMetadataBear
+from bears.vcs.git.CISkipInspectBear import CISkipInspectBear
+from coalib.misc.Shell import run_shell_command
+from coalib.settings.Section import Section
+from coalib.settings.Setting import Setting
+from coalib.testing.BearTestHelper import generate_skip_decorator
+from .GitCommitBearTest import GitCommitBearTest
+
+
+@generate_skip_decorator(CISkipInspectBear)
+class CISkipInspectBearTest(unittest.TestCase):
+
+    def run_uut(self, *args, **kwargs):
+        """
+        Runs the unit-under-test (via `self.uut.run()`) and collects the
+        messages of the yielded results as a list.
+
+        :param args:   Positional arguments to forward to the run function.
+        :param kwargs: Keyword arguments to forward to the run function.
+        :return:       A list of the message strings.
+        """
+        dep_bear = GitCommitMetadataBear(None, self.section, Queue())
+        deps_results = dict(GitCommitMetadataBear=list(dep_bear.run()))
+        return list(result.message for result in self.uut.run(
+            deps_results, *args, **kwargs))
+
+    def setUp(self):
+        self.msg_queue = Queue()
+        self.section = Section('commit')
+        self.section.append(Setting('files', '*Test.py, .coafile'))
+        self.uut = CISkipInspectBear(None, self.section, self.msg_queue)
+
+        self._old_cwd = os.getcwd()
+        self.gitdir = mkdtemp()
+        os.chdir(self.gitdir)
+        GitCommitBearTest.run_git_command('init')
+        GitCommitBearTest.run_git_command(
+            'config', 'user.email coala@coala.io')
+        GitCommitBearTest.run_git_command('config', 'user.name coala')
+
+    @staticmethod
+    def _windows_rmtree_remove_readonly(func, path, excinfo):
+        os.chmod(path, stat.S_IWRITE)
+        func(path)
+
+    def tearDown(self):
+        os.chdir(self._old_cwd)
+        if platform.system() == 'Windows':
+            onerror = self._windows_rmtree_remove_readonly
+        else:
+            onerror = None
+        shutil.rmtree(self.gitdir, onerror=onerror)
+
+    def test_skipci_build_commit(self):
+        Path('file1.txt').touch()
+        run_shell_command('git add file1.txt')
+        run_shell_command('git commit -m "Add file1"')
+        self.assertEqual(
+            self.run_uut(appveyor_ci=True), [])
+
+        Path('file2.txt').touch()
+        run_shell_command('git add file2.txt')
+        run_shell_command('git commit -m "Add file2  [ci skip]"')
+        self.assertEqual(
+            self.run_uut(appveyor_ci=True), [])
+
+        Path('file3.txt').touch()
+        run_shell_command('git add file3.txt')
+        run_shell_command('git commit -m "Add file3  [ci skip]"')
+        self.assertEqual(
+            self.run_uut(appveyor_ci=True), [])
+
+        Path('AbcBearTest.py').touch()
+        run_shell_command('git add AbcBearTest.py')
+        run_shell_command(
+            'git commit -m "AbcBearTest.py: Add first commit\n\n[ci skip]"')
+        self.assertEqual(
+            self.run_uut(appveyor_ci=True), [])
+
+        Path('DefBearTest.py').touch()
+        run_shell_command('git add DefBearTest.py')
+        run_shell_command(
+            'git commit -m "DefBearTest.py: Add next commit\n\n[ci skip]"')
+        self.assertEqual(
+            self.run_uut(),
+            ['This commit modifies a file that has pattern of type '
+             '"*Test.py", thus should not disable CI build.'])
+
+        Path('DefBearTest.py').touch()
+        run_shell_command('git add DefBearTest.py')
+        run_shell_command(
+            'git commit -m "DefBearTest.py: Add next commit [ci skip]"')
+        self.assertEqual(
+            self.run_uut(),
+            ['This commit modifies a file that has pattern of type '
+             '"*Test.py", thus should not disable CI build.'])
+
+        Path('.coafile').touch()
+        run_shell_command('git add .coafile')
+        run_shell_command('git commit -m ".coafile: Add coafile [skip ci]"')
+        self.assertEqual(
+            self.run_uut(appveyor_ci=True),
+            ['This commit modifies a file that has pattern of type '
+             '".coafile", thus should not disable CI build.'])


### PR DESCRIPTION
This bear inspects git commits that
disable CI build.

Closes https://github.com/coala/coala-bears/issues/1976

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
