### PR TITLE
bear-requirements.txt: Bump to PyYAML 4.1.0

### DIFF
--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -28,7 +28,7 @@ pydocstyle~=2.0
 pyflakes~=1.5.0
 pylint~=1.7.2
 pyroma~=2.2.0
-pyyaml~=3.12
+pyyaml~=4.1.0
 radon==1.4.0
 restructuredtext-lint~=1.0.0
 rstcheck~=3.1

--- a/bear-requirements.yaml
+++ b/bear-requirements.yaml
@@ -176,7 +176,7 @@ pip_requirements:
   pyroma:
     version: ~=2.2.0
   pyyaml:
-    version: ~=3.12
+    version: ~=4.1.0
   radon:
     version: ==1.4.0
   restructuredtext-lint:

--- a/bears/ruby/RuboCopBear.py
+++ b/bears/ruby/RuboCopBear.py
@@ -20,7 +20,7 @@ class RuboCopBear:
 
     LANGUAGES = {'Ruby'}
     REQUIREMENTS = {GemRequirement('rubocop', '0.51.0'),
-                    PipRequirement('pyyaml', '3.12')}
+                    PipRequirement('pyyaml', '4.1.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'

--- a/bears/scss/SCSSLintBear.py
+++ b/bears/scss/SCSSLintBear.py
@@ -21,7 +21,7 @@ class SCSSLintBear:
     # require flag is necessary for 'scss_lint'
     # https://github.com/brigade/scss-lint#installation
     REQUIREMENTS = {GemRequirement('scss_lint', '0.56.0', 'false'),
-                    PipRequirement('pyyaml', '3.12')}
+                    PipRequirement('pyyaml', '4.1.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'


### PR DESCRIPTION
Most dependencies are moving to PyYAML 4.x due to its
default secure mode.
The bears pin to 3.12 causes VersionConflict errors
when other yaml tools are in the same environment.

Closes https://github.com/coala/coala/issues/5559

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
