### PR TITLE
FilenameBearTest: Fix testcases

### DIFF
--- a/tests/general/FilenameBearTest.py
+++ b/tests/general/FilenameBearTest.py
@@ -2,6 +2,7 @@ from queue import Queue
 
 from bears.general.FilenameBear import FilenameBear
 from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
+from coalib.results.Diff import Diff
 from coalib.results.Result import RESULT_SEVERITY, Result
 from coalib.output.printers.LOG_LEVEL import LOG_LEVEL
 from coalib.settings.Section import Section
@@ -115,13 +116,16 @@ class FilenameBearTest(LocalBearTestHelper):
             self.uut, [''], filename='filename.xyz')
         self.check_validity(
             self.uut, [''], filename='prefilename.xyz')
+
+        expected_diff = Diff(['\n'], rename='prefilename.xyz')
         self.check_results(
             self.uut,
             [''],
             [Result.from_values('FilenameBear',
                                 "Filename does not use the prefix 'pre'.",
                                 severity=RESULT_SEVERITY.NORMAL,
-                                file='filename.xyz')],
+                                file='filename.xyz',
+                                diffs={'filename.xyz': expected_diff})],
             filename='filename.xyz')
 
     def test_file_suffix(self):
@@ -130,18 +134,23 @@ class FilenameBearTest(LocalBearTestHelper):
             self.uut, [''], filename='filename.xyz')
         self.check_validity(
             self.uut, [''], filename='filenamesuffix.xyz')
+
+        expected_diff = Diff(['\n'], rename='filenamefix.xyz')
         self.check_results(
             self.uut,
             [''],
             [Result.from_values('FilenameBear',
                                 "Filename does not use the suffix 'fix'.",
                                 severity=RESULT_SEVERITY.NORMAL,
-                                file='filename.xyz')],
+                                file='filename.xyz',
+                                diffs={'filename.xyz': expected_diff})],
             filename='filename.xyz')
 
     def test_file_prefix_suffix(self):
         self.section['filename_prefix'] = 'pre'
         self.section['filename_suffix'] = 'fix'
+
+        expected_diff = Diff(['\n'], rename='prefilenamefix.xyz')
         self.check_results(
             self.uut,
             [''],
@@ -149,7 +158,8 @@ class FilenameBearTest(LocalBearTestHelper):
                                 "- Filename does not use the prefix 'pre'.\n"
                                 "- Filename does not use the suffix 'fix'.",
                                 severity=RESULT_SEVERITY.NORMAL,
-                                file='filename.xyz')],
+                                file='filename.xyz',
+                                diffs={'filename.xyz': expected_diff})],
             filename='filename.xyz')
 
     def test_file_with_too_long_filename(self):
@@ -181,6 +191,8 @@ class FilenameBearTest(LocalBearTestHelper):
         msg = ("- Filename does not use the prefix 'pre'.\n"
                '- Filename is too long ({} > {}).'
                )
+
+        expected_diff = Diff(['\n'], rename=('pre' + filename_test1))
         self.check_results(
             self.uut,
             [''],
@@ -188,5 +200,6 @@ class FilenameBearTest(LocalBearTestHelper):
                                 msg.format(len(filename_test1),
                                            max_filename_length),
                                 severity=RESULT_SEVERITY.NORMAL,
-                                file=filename_test1)],
+                                file=filename_test1,
+                                diffs={filename_test1: expected_diff})],
             filename=filename_test1)


### PR DESCRIPTION
Match several testcases in `FilenameBearTest` with the actual
result, especially for the expected `Result` objects that
its `diffs` argument was forgotten.

Closes https://github.com/coala/coala-bears/issues/2564

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
