### PR TITLE
ClangComplexityBear: Fix SourceRange AttributeError

### DIFF
--- a/bears/c_languages/ClangComplexityBear.py
+++ b/bears/c_languages/ClangComplexityBear.py
@@ -2,9 +2,10 @@ from clang.cindex import Index, CursorKind
 
 from coalib.bears.LocalBear import LocalBear
 from coalib.results.Result import Result
-from coalib.results.SourceRange import SourceRange
 from coalib.bearlib import deprecate_settings
-from bears.c_languages.ClangBear import clang_available, ClangBear
+from bears.c_languages.ClangBear import (
+    clang_available, ClangBear, sourcerange_from_clang_range,
+)
 
 
 class ClangComplexityBear(LocalBear):
@@ -98,7 +99,7 @@ class ClangComplexityBear(LocalBear):
         root = Index.create().parse(filename).cursor
         for cursor, complexity in self.complexities(root, filename):
             if complexity > cyclomatic_complexity:
-                affected_code = (SourceRange.from_clang_range(cursor.extent),)
+                affected_code = (sourcerange_from_clang_range(cursor.extent),)
                 yield Result(
                     self,
                     "The function '{function}' should be simplified. Its "


### PR DESCRIPTION
This fixes AttributeError by replacing previously removed
function of `SourceRange` with `sourcerange_from_clang_range`
function.

Fixes https://github.com/coala/coala-bears/issues/2570

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
