### PR TITLE
ClangBear.py: Rename range to range_obj

### DIFF
--- a/bears/c_languages/ClangBear.py
+++ b/bears/c_languages/ClangBear.py
@@ -52,17 +52,17 @@ def diff_from_clang_fixit(fixit, file):
     return Diff.from_string_arrays(file, new_file)
 
 
-def sourcerange_from_clang_range(range):
+def sourcerange_from_clang_range(range_obj):
     """
     Creates a ``SourceRange`` from a clang ``SourceRange`` object.
 
-    :param range: A ``cindex.SourceRange`` object.
+    :param range_obj: A ``cindex.SourceRange`` object.
     """
-    return SourceRange.from_values(range.start.file.name,
-                                   range.start.line,
-                                   range.start.column,
-                                   range.end.line,
-                                   range.end.column)
+    return SourceRange.from_values(range_obj.start.file.name,
+                                   range_obj.start.line,
+                                   range_obj.start.column,
+                                   range_obj.end.line,
+                                   range_obj.end.column)
 
 
 class ClangBear(LocalBear):
@@ -99,8 +99,8 @@ class ClangBear(LocalBear):
                         2: RESULT_SEVERITY.NORMAL,
                         3: RESULT_SEVERITY.MAJOR,
                         4: RESULT_SEVERITY.MAJOR}.get(diag.severity)
-            affected_code = tuple(sourcerange_from_clang_range(range)
-                                  for range in diag.ranges)
+            affected_code = tuple(sourcerange_from_clang_range(range_obj)
+                                  for range_obj in diag.ranges)
 
             diffs = None
             fixits = list(diag.fixits)


### PR DESCRIPTION
This prevents renaming of the range keyword from range --> range_obj in
ClangBear.py.

Closes https://github.com/coala/coala-bears/issues/2585

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
