### PR TITLE
TextLintBearTest: Replace httpstat.us with Google

### DIFF
--- a/tests/general/TextLintBearTest.py
+++ b/tests/general/TextLintBearTest.py
@@ -148,8 +148,8 @@ class TextLintBearTest(LocalBearTestHelper):
                                 severity=RESULT_SEVERITY.MAJOR,
                                 file=get_testfile_path(file_name)),
              Result.from_values('TextLintBear',
-                                message='http://httpstat.us/404 is dead. '
-                                        '(404 Not Found)',
+                                message='https://google.com/teapot is dead. '
+                                        '(301 Moved Permanently)',
                                 line=2,
                                 column=5,
                                 severity=RESULT_SEVERITY.MAJOR,

--- a/tests/general/textlint_test_files/bad_alex_no_dead_link.md
+++ b/tests/general/textlint_test_files/bad_alex_no_dead_link.md
@@ -1,2 +1,2 @@
 We've confirmed his identity.
-The http://httpstat.us/404 link should report an error.
+The https://google.com/teapot link should report an error.


### PR DESCRIPTION
httpstat.us and httpbin.org have repeatedly been
causing failures in tests for days at a time.
The Google Teapot is a reliable error page.

Closes https://github.com/coala/coala-bears/issues/2588

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
