### PR TITLE
Jinja2Bear: Disable the need of trailing comment

### DIFF
--- a/bears/jinja2/Jinja2Bear.py
+++ b/bears/jinja2/Jinja2Bear.py
@@ -267,7 +267,8 @@ class Jinja2Bear(LocalBear):
                                filename,
                                line,
                                line_number,
-                               control_spacing):
+                               control_spacing,
+                               check_end_labels):
         """
         Checks any control end tag in the given line for spacing issues,
         missing/wrong labels or missing corresponding opening tag.
@@ -307,6 +308,9 @@ class Jinja2Bear(LocalBear):
             if not has_required_spacing(m.group('content'), control_spacing):
                 yield self.handle_control_spacing_issue(
                     file, filename, line, line_number, control_spacing, m)
+
+            if not check_end_labels:
+                return
 
             # yield results for incorrect or missing end labels
             if label is None and line_number != start_in_line:
@@ -356,6 +360,7 @@ class Jinja2Bear(LocalBear):
             variable_spacing: int = 1,
             statement_spacing: int = 1,
             control_spacing: int = 1,
+            check_end_labels: bool = True,
             ):
         """
         Check `Jinja2 templates <http://jinja.pocoo.org>`_ for syntax,
@@ -420,7 +425,9 @@ class Jinja2Bear(LocalBear):
                 file, filename, line, line_number, control_spacing)
 
             yield from self.check_control_end_tags(
-                file, filename, line, line_number, control_spacing)
+                file, filename, line, line_number, control_spacing,
+                check_end_labels,
+            )
 
         # We've reached the end of the file.
         # Check if all control blocks have been closed

--- a/tests/jinja2/Jinja2BearTest.py
+++ b/tests/jinja2/Jinja2BearTest.py
@@ -164,6 +164,26 @@ Jinja2BearForLoopLabelTest = verify_local_bear(
     valid_files=(good_file1, good_file2, good_file3),
     invalid_files=(bad_file1, bad_file2))
 
+valid_file_without_end_comments = """
+foo
+{% for x in something %}
+render stuff
+{% endfor %}
+"""
+
+valid_file_with_end_comments = """
+foo
+{% for x in something %}
+render stuff
+{% endfor %}{# for x in something #}
+"""
+
+Jinja2BearForLoopLabelDisableTest = verify_local_bear(
+    Jinja2Bear,
+    valid_files=(valid_file_without_end_comments, valid_file_with_end_comments),
+    invalid_files=(),
+    settings={'check_end_labels': 'False'})
+
 
 class Jinja2BearLabelDiffTest(unittest.TestCase):
 


### PR DESCRIPTION
This enables the end of block to not have comment.
However by default it would check for the trailing comment
But the behavior can be changed by the user explicitly.

Closes https://github.com/coala/coala-bears/issues/2659

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
