### PR TITLE
TailorBearTest.py & TSLintBearTest.py : Change test variables name

### DIFF
--- a/tests/swift/TailorBearTest.py
+++ b/tests/swift/TailorBearTest.py
@@ -24,22 +24,22 @@ long_class_file = """class LongClass {
 }
 """
 
-TailorBearWithoutConfig = verify_local_bear(TailorBear,
-                                            valid_files=(good_file,),
-                                            invalid_files=(bad_file,),
-                                            tempfile_kwargs={
-                                                'suffix': '.swift'})
+TailorBearWithoutConfigTest = verify_local_bear(
+    TailorBear,
+    valid_files=(good_file,),
+    invalid_files=(bad_file,),
+    tempfile_kwargs={'suffix': '.swift'})
 
-TailorBearWithConfig = verify_local_bear(TailorBear,
-                                         valid_files=(bad_file,),
-                                         invalid_files=(),
-                                         settings={
-                                             'tailor_config': tailorconfig},
-                                         tempfile_kwargs={'suffix': '.swift'})
+TailorBearWithConfigTest = verify_local_bear(
+    TailorBear,
+    valid_files=(bad_file,),
+    invalid_files=(),
+    settings={'tailor_config': tailorconfig},
+    tempfile_kwargs={'suffix': '.swift'})
 
-TailorBearWithSetting = verify_local_bear(TailorBear,
-                                          valid_files=(),
-                                          invalid_files=(long_class_file,),
-                                          settings={
-                                              'max_class_length': 2},
-                                          tempfile_kwargs={'suffix': '.swift'})
+TailorBearWithSettingTest = verify_local_bear(
+    TailorBear,
+    valid_files=(),
+    invalid_files=(long_class_file,),
+    settings={'max_class_length': 2},
+    tempfile_kwargs={'suffix': '.swift'})

--- a/tests/typescript/TSLintBearTest.py
+++ b/tests/typescript/TSLintBearTest.py
@@ -23,20 +23,22 @@ tslintconfig = os.path.join(os.path.dirname(__file__),
                             'test_files',
                             'tslint.json')
 
-TSLintBearWithoutConfig = verify_local_bear(TSLintBear,
-                                            valid_files=(good_file,),
-                                            invalid_files=(bad_file,),
-                                            tempfile_kwargs={'suffix': '.ts'})
+TSLintBearWithoutConfigTest = verify_local_bear(
+    TSLintBear,
+    valid_files=(good_file,),
+    invalid_files=(bad_file,),
+    tempfile_kwargs={'suffix': '.ts'})
 
-TSLintBearTestWithConfig = verify_local_bear(TSLintBear,
-                                             valid_files=(bad_file,),
-                                             invalid_files=(good_file,),
-                                             settings={'tslint_config':
-                                                       tslintconfig},
-                                             tempfile_kwargs={'suffix': '.ts'})
+TSLintBearWithConfigTest = verify_local_bear(
+    TSLintBear,
+    valid_files=(bad_file,),
+    invalid_files=(good_file,),
+    settings={'tslint_config': tslintconfig},
+    tempfile_kwargs={'suffix': '.ts'})
 
-TSLintBearOtherOptions = verify_local_bear(TSLintBear,
-                                           valid_files=(good_file,),
-                                           invalid_files=(bad_file,),
-                                           settings={'rules_dir': '/'},
-                                           tempfile_kwargs={'suffix': '.ts'})
+TSLintBearOtherOptionsTest = verify_local_bear(
+    TSLintBear,
+    valid_files=(good_file,),
+    invalid_files=(bad_file,),
+    settings={'rules_dir': '/'},
+    tempfile_kwargs={'suffix': '.ts'})


### PR DESCRIPTION
Ensures that name of tests are consistent with other test modules
that use verify_local_bear

Closes https://github.com/coala/coala-bears/issues/1733
