### PR TITLE
.travis.yml : removed CIRCLE_NODE_INDEX=-1 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -157,7 +157,6 @@ cache:
 env:
   global:
     - TERM=dumb
-    - CIRCLE_NODE_INDEX=-1  # Avoid accidentially being a CircleCI worker
     - R_LIB_USER=~/R/Library
     - LINTR_COMMENT_BOT=false
     - CABAL_VERSION=1.24


### PR DESCRIPTION
closes #2453 
Removed `CIRCLE_NODE_INDEX=-1` from `.travis.yml`