### PR TITLE
PEP8Bear.py: Change the docstring Indentation

### DIFF
--- a/bears/python/PEP8Bear.py
+++ b/bears/python/PEP8Bear.py
@@ -31,14 +31,18 @@ class PEP8Bear(LocalBear):
         Detects and fixes PEP8 incompliant code. This bear will not change
         functionality of the code in any way.
 
-        :param max_line_length:   Maximum number of characters for a line.
-                                  When set to 0 allows infinite line length.
-        :param indent_size:       Number of spaces per indentation level.
-        :param pep_ignore:        A list of errors/warnings to ignore.
-        :param pep_select:        A list of errors/warnings to exclusively
-                                  apply.
-        :param local_pep8_config: Set to true if autopep8 should use a config
-                                  file as if run normally from this directory.
+        :param max_line_length:
+            Maximum number of characters for a line.
+            When set to 0 allows infinite line length.
+        :param indent_size:
+            Number of spaces per indentation level.
+        :param pep_ignore:
+            A list of errors/warnings to ignore.
+        :param pep_select:
+            A list of errors/warnings to exclusively apply.
+        :param local_pep8_config:
+            Set to true if autopep8 should use a config file as if run normally
+            from this directory.
         """
         if not max_line_length:
             max_line_length = sys.maxsize


### PR DESCRIPTION
Change in the docstring indentations in PEP8Bear.py
according to reStructured format supported by
Sphinx 1.5.6 to make the docstring parameters more visible.

Closes https://github.com/coala/coala-bears/issues/2437

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
