### PR TITLE
PEP8NoteBear: Add infinite line length

### DIFF
--- a/bears/python/PEP8NotebookBear.py
+++ b/bears/python/PEP8NotebookBear.py
@@ -1,5 +1,6 @@
 import autopep8
 import nbformat
+import sys
 
 from coalib.bearlib.spacing.SpacingHelper import SpacingHelper
 from coalib.bears.LocalBear import LocalBear
@@ -84,6 +85,7 @@ class PEP8NotebookBear(LocalBear):
         will not change functionality of the code in any way.
 
         :param max_line_length:   Maximum number of characters for a line.
+                                  When set to 0 allows infinite line length.
         :param indent_size:       Number of spaces per indent level.
         :param pep_ignore:        A list of errors/warnings to ignore.
         :param pep_select:        A list of errors/warnings to exclusively
@@ -91,6 +93,9 @@ class PEP8NotebookBear(LocalBear):
         :param local_pep8_config: Set to true if autopep8 should use a config
                                   file as if run normally from this directory.
         """
+        if not max_line_length:
+            max_line_length = sys.maxsize
+
         options = {'ignore': pep_ignore,
                    'select': pep_select,
                    'max_line_length': max_line_length,

--- a/tests/python/PEP8NotebookBearTest.py
+++ b/tests/python/PEP8NotebookBearTest.py
@@ -22,6 +22,20 @@ good_file = r"""{
    "source": [
     "a markdown cell is not a code cell"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "options": {
+    "max_line_length": 0
+   },
+   "outputs": [],
+   "source": [
+    "'x =' + ' 1 +' * 100 + ' 1'"
+   ]
   }
  ],
  "metadata": {},


### PR DESCRIPTION
Allows infinite line length when
max_line_length is set to 0.

Closes https://github.com/coala/coala-bears/issues/2443