### PR TITLE
PEP8NotebookBear.py: Correct the spelling mistake in docstring #2703

### DIFF
--- a/bears/python/PEP8NotebookBear.py
+++ b/bears/python/PEP8NotebookBear.py
@@ -8,7 +8,7 @@ from coalib.results.Diff import Diff
 from coalib.results.Result import Result
 from coalib.settings.Setting import typed_list
 
-# Comments regarind Jupyter Notebooks:
+# Comments regarding Jupyter Notebooks:
 # The `nbformat` module contains the reference implementation of the Jupyter
 # Notebook format, and Python APIs for working with notebooks.
 # On the file level, a notebook is a JSON file, i.e. dictionary with a few


### PR DESCRIPTION
Fixed spelling mistake, error issue #2703. 
Sorry if this is not the right standard to do a pull request, but is my first one so bear with me please :)