### PR TITLE
Change C++ to CPP at bears language

### DIFF
--- a/bears/c_languages/ArtisticStyleBear.py
+++ b/bears/c_languages/ArtisticStyleBear.py
@@ -13,7 +13,7 @@ class ArtisticStyleBear:
     C# and Java programming languages.
     """
 
-    LANGUAGES = {'C', 'C++', 'Objective-C', 'C#', 'Java'}
+    LANGUAGES = {'C', 'CPP', 'Objective-C', 'C#', 'Java'}
     REQUIREMENTS = {
         DistributionRequirement(
             apt_get='astyle',

--- a/bears/c_languages/CPPCheckBear.py
+++ b/bears/c_languages/CPPCheckBear.py
@@ -21,7 +21,7 @@ class CPPCheckBear:
     For more information, consult <https://github.com/danmar/cppcheck>.
     """
 
-    LANGUAGES = {'C', 'C++'}
+    LANGUAGES = {'C', 'CPP'}
     REQUIREMENTS = {DistributionRequirement('cppcheck')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}

--- a/bears/c_languages/CPPCleanBear.py
+++ b/bears/c_languages/CPPCleanBear.py
@@ -15,7 +15,7 @@ class CPPCleanBear:
     <https://github.com/myint/cppclean#features>.
     """
 
-    LANGUAGES = {'C++'}
+    LANGUAGES = {'CPP'}
     REQUIREMENTS = {PipRequirement('cppclean', '0.12.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}

--- a/bears/c_languages/CPPLintBear.py
+++ b/bears/c_languages/CPPLintBear.py
@@ -18,7 +18,7 @@ class CPPLintBear:
     For more information, consult <https://github.com/theandrewdavis/cpplint>.
     """
 
-    LANGUAGES = {'C++'}
+    LANGUAGES = {'CPP'}
     REQUIREMENTS = {PipRequirement('cpplint', '1.3')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}

--- a/bears/c_languages/CSecurityBear.py
+++ b/bears/c_languages/CSecurityBear.py
@@ -27,7 +27,7 @@ class CSecurityBear:
     For more information, consult <http://www.dwheeler.com/flawfinder/>.
     """
 
-    LANGUAGES = {'C', 'C++'}
+    LANGUAGES = {'C', 'CPP'}
     REQUIREMENTS = {DistributionRequirement('flawfinder')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}

--- a/bears/c_languages/ClangBear.py
+++ b/bears/c_languages/ClangBear.py
@@ -66,7 +66,7 @@ def sourcerange_from_clang_range(clang_range):
 
 
 class ClangBear(LocalBear):
-    LANGUAGES = {'C', 'C++', 'Objective-C', 'Objective-C++', 'OpenMP',
+    LANGUAGES = {'C', 'CPP', 'Objective-C', 'Objective-C++', 'OpenMP',
                  'OpenCL', 'CUDA'}
     # Depends on libclang-py3, which is a dependency of coala
     REQUIREMENTS = {PipRequirement('libclang-py3', '3.4.0')}

--- a/bears/c_languages/GNUIndentBear.py
+++ b/bears/c_languages/GNUIndentBear.py
@@ -21,7 +21,7 @@ class GNUIndentBear:
     C++ support is considered experimental.
     """
 
-    LANGUAGES = {'C', 'C++'}
+    LANGUAGES = {'C', 'CPP'}
     REQUIREMENTS = {DistributionRequirement('indent')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}


### PR DESCRIPTION
To have a standard naming convention for language
names so that C++ and CPP are treated as same language.

Closes https://github.com/coala/coala-bears/issues/2715

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
