### PR TITLE
JSONFormatBear.py: Implement max_line_length

### DIFF
--- a/tests/js/JSONFormatBearTest.py
+++ b/tests/js/JSONFormatBearTest.py
@@ -35,6 +35,13 @@ test_file4 = """{
 }"""
 
 
+# This will generate a line with 80 characters
+max_line_length_file1 = '{\n    "string": "' + 'a' * 64 + '"\n}'
+
+# This will generate a line with 79 characters
+max_line_length_file2 = '{\n    "string": "' + 'a' * 63 + '"\n}'
+
+
 class JSONTest(LocalBearTestHelper):
 
     def setUp(self):
@@ -91,3 +98,19 @@ JSONFormatBearUnicodeTest = verify_local_bear(JSONFormatBear,
                                               invalid_files=(),
                                               settings={'escape_unicode':
                                                         'false'})
+
+
+JSONFormatBearInfLineLengthTest = verify_local_bear(JSONFormatBear,
+                                                    valid_files=(
+                                                        max_line_length_file1,
+                                                        max_line_length_file2),
+                                                    invalid_files=())
+
+
+JSONFormatBearLineLengthTest = verify_local_bear(JSONFormatBear,
+                                                 valid_files=(
+                                                     max_line_length_file2,),
+                                                 invalid_files=(
+                                                     max_line_length_file1,),
+                                                 settings={'max_line_length':
+                                                           '79'})


### PR DESCRIPTION
The max_line_length for JSON is infinity by default.
It can be modified if a user is sure about the line length.

Closes https://github.com/coala/coala-bears/issues/2743

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
