### PR TITLE
CommitBear.py: Check proper use of `https` when referencing issues

### DIFF
--- a/bears/vcs/CommitBear.py
+++ b/bears/vcs/CommitBear.py
@@ -1,4 +1,3 @@
-
 import abc
 import logging
 import nltk
@@ -25,11 +24,11 @@ class _CommitBear(GlobalBear):
     ISSUE_INFO = {
         'github': {
             'issue': r'(?:\w+/\w+)?#(\d+)',
-            'full issue': r'https?://github\S+/issues/(\d+)',
+            'full issue': r'https://github\S+/issues/(\d+)',
         },
         'gitlab': {
             'issue': r'(?:\w+/\w+)?#(\d+)',
-            'full issue': r'https?://gitlab\S+/issues/(\d+)',
+            'full issue': r'https://gitlab\S+/issues/(\d+)',
         },
         'bitbucket': {
             'issue': r'#(\d+)',
@@ -386,8 +385,9 @@ class _CommitBear(GlobalBear):
             for issue in re.split(compiled_concat_regex, match):
                 reference = compiled_issue_ref_regex.fullmatch(issue)
                 if not reference:
-                    yield Result(self, 'Invalid {} reference: '
-                                       '{}'.format(self.issue_type, issue))
+                    yield Result(self, 'Invalid {} {} reference: '
+                                       '{}'.format(host, self.issue_type,
+                                                   issue))
                 elif not compiled_issue_no_regex.fullmatch(reference.group(1)):
-                    yield Result(self, 'Invalid issue number: '
-                                       '{}'.format(issue))
+                    yield Result(self, 'Invalid {} issue number: '
+                                       '{}'.format(host, issue))

--- a/tests/vcs/git/GitCommitBearTest.py
+++ b/tests/vcs/git/GitCommitBearTest.py
@@ -354,7 +354,7 @@ class GitCommitBearTest(unittest.TestCase):
                         'Resolves https://bitbucket.org/user/repo/issues/1/')
         self.assertEqual(self.run_uut(
                              body_close_issue=True),
-                         ['Invalid issue reference: '
+                         ['Invalid bitbucket issue reference: '
                           'https://bitbucket.org/user/repo/issues/1/'])
 
         self.git_commit('Shortlog\n\n'
@@ -403,7 +403,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_enforce_issue_reference=True),
-                         ['Invalid issue reference: bug#1112'])
+                         ['Invalid bitbucket issue reference: bug#1112'])
 
         self.git_commit('Shortlog\n\n'
                         'First line, blablablablablabla.\n'
@@ -412,7 +412,8 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_enforce_issue_reference=True),
-                         ['Invalid issue reference: randomkeyword#1112'])
+                         ['Invalid bitbucket issue reference: '
+                          'randomkeyword#1112'])
 
         self.git_commit('Shortlog\n\n'
                         'First line, blablablablablabla.\n'
@@ -431,7 +432,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_enforce_issue_reference=True),
-                         ['Invalid issue reference: bug'])
+                         ['Invalid bitbucket issue reference: bug'])
 
         self.git_commit('Shortlog\n\n'
                         'First line, blablablablablabla.\n'
@@ -449,7 +450,7 @@ class GitCommitBearTest(unittest.TestCase):
                         'Resolves https://bitbucket.org/user/repo/issues/1/')
         self.assertEqual(self.run_uut(
                              body_close_issue=True),
-                         ['Invalid issue reference: '
+                         ['Invalid bitbucket issue reference: '
                           'https://bitbucket.org/user/repo/issues/1/'])
 
         self.git_commit('Shortlog\n\n'
@@ -501,7 +502,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_close_issue_full_url=True),
-                         ['Invalid full issue reference: '
+                         ['Invalid github full issue reference: '
                           'https://github.com/user/repo.git'])
         self.assert_no_msgs()
 
@@ -518,7 +519,7 @@ class GitCommitBearTest(unittest.TestCase):
                         'Another line, blablablablablabla.\n'
                         'Fix #01112 and #111')
         self.assertEqual(self.run_uut(body_close_issue=True,),
-                         ['Invalid issue number: #01112'])
+                         ['Invalid github issue number: #01112'])
         self.assert_no_msgs()
 
         # GitHub host with no full issue reference
@@ -529,7 +530,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_close_issue_full_url=True),
-                         ['Invalid full issue reference: #1112'])
+                         ['Invalid github full issue reference: #1112'])
         self.assert_no_msgs()
 
         # Invalid characters in issue number
@@ -540,7 +541,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_close_issue_full_url=True),
-                         ['Invalid full issue reference: #1112-3'])
+                         ['Invalid github full issue reference: #1112-3'])
         self.assert_no_msgs()
 
         # Adding GitLab remote for testing
@@ -566,7 +567,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_close_issue_full_url=True),
-                         ['Invalid full issue reference: '
+                         ['Invalid gitlab full issue reference: '
                           'https://gitlab.com/user/repo/issues/not_num'])
         self.assert_no_msgs()
 
@@ -578,7 +579,7 @@ class GitCommitBearTest(unittest.TestCase):
         self.assertEqual(self.run_uut(
                              body_close_issue=True,
                              body_close_issue_full_url=True),
-                         ['Invalid full issue reference: '
+                         ['Invalid gitlab full issue reference: '
                           'www.google.com/issues/hehehe'])
         self.assert_no_msgs()
 
@@ -588,7 +589,7 @@ class GitCommitBearTest(unittest.TestCase):
                         'Another line, blablablablablabla.\n'
                         'Resolve #11 and close #notnum')
         self.assertEqual(self.run_uut(body_close_issue=True,),
-                         ['Invalid issue reference: #notnum'])
+                         ['Invalid gitlab issue reference: #notnum'])
         self.assert_no_msgs()
 
         # Close issues in other repos
@@ -605,7 +606,7 @@ class GitCommitBearTest(unittest.TestCase):
                         'Another line, blablablablablabla.\n'
                         'Fix #11 and close github#32')
         self.assertEqual(self.run_uut(body_close_issue=True,),
-                         ['Invalid issue reference: github#32'])
+                         ['Invalid gitlab issue reference: github#32'])
         self.assert_no_msgs()
 
         # Last line enforce full URL

--- a/tests/vcs/mercurial/HgCommitBearTest.py
+++ b/tests/vcs/mercurial/HgCommitBearTest.py
@@ -303,7 +303,7 @@ class HgCommitBearTest(unittest.TestCase):
                        'Closes #01112')
         self.assertEqual(self.run_uut(body_close_issue=True,
                                       body_enforce_issue_reference=True),
-                         ['Invalid issue number: #01112'])
+                         ['Invalid bitbucket issue number: #01112'])
 
         # Adding incompatible remote for testing
         new_config_file = ('[paths]\n'
@@ -338,7 +338,7 @@ class HgCommitBearTest(unittest.TestCase):
                        'Closes #01112')
         self.assertEqual(self.run_uut(body_close_issue=True,
                                       body_enforce_issue_reference=True),
-                         ['Invalid issue number: #01112'])
+                         ['Invalid bitbucket issue number: #01112'])
 
         # No keywords and no issues
         self.hg_commit('Shortlog\n\n'
@@ -384,7 +384,7 @@ class HgCommitBearTest(unittest.TestCase):
                        'Another line, blablablablablabla.\n'
                        'Fix #01112 and #111')
         self.assertEqual(self.run_uut(body_close_issue=True,),
-                         ['Invalid issue number: #01112'])
+                         ['Invalid bitbucket issue number: #01112'])
         self.assert_no_msgs()
 
         # Bitbucket host with no full issue reference
@@ -406,7 +406,7 @@ class HgCommitBearTest(unittest.TestCase):
                        'Fix #1112-3')
         self.assertEqual(self.run_uut(
                              body_close_issue=True),
-                         ['Invalid issue reference: #1112-3'])
+                         ['Invalid bitbucket issue reference: #1112-3'])
         self.assert_no_msgs()
 
         # One of the short references is broken
@@ -415,7 +415,7 @@ class HgCommitBearTest(unittest.TestCase):
                        'Another line, blablablablablabla.\n'
                        'Resolve #11 and closes #notnum')
         self.assertEqual(self.run_uut(body_close_issue=True),
-                         ['Invalid issue reference: #notnum'])
+                         ['Invalid bitbucket issue reference: #notnum'])
         self.assert_no_msgs()
 
         # Incorrect close issue other repo pattern
@@ -424,5 +424,5 @@ class HgCommitBearTest(unittest.TestCase):
                        'Another line, blablablablablabla.\n'
                        'Fix #11 and close bitbucket#32')
         self.assertEqual(self.run_uut(body_close_issue=True),
-                         ['Invalid issue reference: bitbucket#32'])
+                         ['Invalid bitbucket issue reference: bitbucket#32'])
         self.assert_no_msgs()


### PR DESCRIPTION
Check if commit message uses 'https' rather than 'http' to automatically close the referenced issue for GitHub and GitLab. Yield host to user if error is caught.

Closes https://github.com/coala/coala-bears/issues/2683
Closes https://github.com/coala/coala-bears/issues/2722