### PR TITLE
Backwards compatibility for process_output handling empty linter results

### DIFF
--- a/.nocover.yaml
+++ b/.nocover.yaml
@@ -8,3 +8,8 @@ nocover_file_globs:
 nocover_regexes:
   # `.` can only be `#`
   - 'if .*:  . backwards compatible no results'
+
+nocover_branch_regexes:
+  # Allows retaining existing indentation
+  # `.` can only be `#`
+  - 'if True:  . no else'

--- a/.nocover.yaml
+++ b/.nocover.yaml
@@ -4,3 +4,7 @@ allow_generic_no_cover: true
 
 nocover_file_globs:
   - .ci/*
+
+nocover_regexes:
+  # `.` can only be `#`
+  - 'if .*:  . backwards compatible no results'

--- a/bears/js/JSComplexityBear.py
+++ b/bears/js/JSComplexityBear.py
@@ -34,7 +34,10 @@ class JSComplexityBear:
         :param cc_threshold: Threshold value for cyclomatic complexity
         """
         message = '{} has a cyclomatic complexity of {}.'
-        if output:
+        if not output:  # backwards compatible no results
+            return
+
+        if True:  # no else
             try:
                 output = json.loads(output)
             except JSONDecodeError:

--- a/bears/python/PycodestyleBear.py
+++ b/bears/python/PycodestyleBear.py
@@ -72,8 +72,11 @@ class PycodestyleBear:
         return arguments
 
     def process_output(self, output, filename, file):
+        if not output:  # backwards compatible no results
+            return
         result = re.match(OUTPUT_REGEX, output)
-        if not result:
+        if not result:  # backwards compatible no results
+            self.warn('{}: Unexpected output {}'.format(filename, output))
             return
         line, column, message, rule = result.groups()
         if rule == 'E501':

--- a/bears/scss/SASSLintBear.py
+++ b/bears/scss/SASSLintBear.py
@@ -40,7 +40,7 @@ class SASSLintBear:
         return args
 
     def process_output(self, output, filename, file):
-        if not file or not output:
+        if not output:  # backwards compatible no results
             return
 
         output = json.loads(output)

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,4 +76,5 @@ partial_branches =
   pragma: no ?branch
   pragma.* ${PLATFORM_SYSTEM}: no branch
   pragma.* ${OS_NAME}: no branch
+  if True:  . no else
 [coverage:force_end_of_section]

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,5 +70,10 @@ exclude_lines =
   pragma ${PLATFORM_SYSTEM}: no cover
   pragma ${OS_NAME}: no cover
   pragma Python [0-9.,]*${PYTHON_VERSION}[0-9.,]*: no cover
+  if .*:  . backwards compatible no results
 
+partial_branches =
+  pragma: no ?branch
+  pragma.* ${PLATFORM_SYSTEM}: no branch
+  pragma.* ${OS_NAME}: no branch
 [coverage:force_end_of_section]


### PR DESCRIPTION
Depends on https://github.com/coala/coala-bears/pull/2658 which in turn depends on https://github.com/coala/coala-bears/pull/2758