### PR TITLE
PyStringConcatBear.py: Add Py string concat bear

### DIFF
--- a/bear-languages.yaml
+++ b/bear-languages.yaml
@@ -297,6 +297,10 @@ PySafetyBear:
   - Python 2 Requirements
   - Python 3 Requirements
   - Python Requirements
+PyStringConcatBear:
+  - Python
+  - Python 2
+  - Python 3
 PyUnusedCodeBear:
   - Python
   - Python 2

--- a/bears/python/PyStringConcatBear.py
+++ b/bears/python/PyStringConcatBear.py
@@ -1,0 +1,37 @@
+from coalib.bears.LocalBear import LocalBear
+from coalib.results.Result import Result
+
+
+class PyStringConcatBear(LocalBear):
+    LANGUAGES = {'Python', 'Python 2', 'Python 3'}
+    CAN_DETECT = {'Formatting'}
+
+    def run(self, filename, file):
+        """
+        Detects use of explicit string concatenation in Python using `+`, which
+        should be avoided.
+
+        :param filename:
+            Name of the file that needs to be checked.
+        :param file:
+            File that needs to be checked in the form of a list of strings.
+        """
+        string_enclosings = ['\"', '`', '\'']
+
+        for line_number, line in enumerate(file):
+            if len(line.strip()) > 0:
+                if line[-2:-1] in '+':
+                    next_line = file[line_number+1]
+                    first_char = len(next_line) - len(next_line.lstrip())
+
+                    if next_line[first_char] in string_enclosings:
+                        yield Result.from_values(
+                            origin=self,
+                            message='Use of explicit string concatenation with '
+                            '`+` should be avoided.',
+                            file=filename,
+                            line=line_number + 1,
+                            column=len(line) - 1,
+                            end_line=line_number + 2,
+                            end_column=len(line)
+                            )

--- a/tests/python/PyStringConcatBearTest.py
+++ b/tests/python/PyStringConcatBearTest.py
@@ -1,0 +1,83 @@
+from queue import Queue
+
+from bears.python.PyStringConcatBear import PyStringConcatBear
+from coalib.testing.LocalBearTestHelper import LocalBearTestHelper
+from coalib.results.Result import Result
+from coalib.settings.Section import Section
+
+
+valid_string = """
+string = 'foo'
+         'bar'
+"""
+
+concat_non_string = """
+list = [] +
+       []
+"""
+
+invalid_single_quote_string = """
+string = 'foo' +
+         'bar'
+"""
+
+invalid_double_quote_string = """
+string = "foo" +
+         "bar"
+"""
+
+invalid_acute_string = """
+string = `foo` +
+         `bar`
+"""
+
+
+class PyStringConcatBearTest(LocalBearTestHelper):
+
+    def setUp(self):
+        self.uut = PyStringConcatBear(Section('name'), Queue())
+
+    def test_valid(self):
+        self.check_validity(self.uut, valid_string.splitlines())
+
+    def test_non_string(self):
+        self.check_validity(self.uut, concat_non_string.splitlines())
+
+    def test_single_quote_string_invalid(self):
+        self.check_results(
+            self.uut,
+            invalid_single_quote_string.splitlines(),
+            [Result.from_values(
+                'PyStringConcatBear',
+                'Use of explicit string concatenation with `+` '
+                'should be avoided.',
+                line=2, column=16, end_line=3, end_column=17, file='default')
+             ],
+            filename='default'
+            )
+
+    def test_double_quote_string_invalid(self):
+        self.check_results(
+            self.uut,
+            invalid_double_quote_string.splitlines(),
+            [Result.from_values(
+                'PyStringConcatBear',
+                'Use of explicit string concatenation with `+` '
+                'should be avoided.',
+                line=2, column=16, end_line=3, end_column=17, file='default')
+             ],
+            filename='default'
+            )
+
+    def test_acute_string_invalid(self):
+        self.check_results(
+            self.uut,
+            invalid_acute_string.splitlines(),
+            [Result.from_values(
+                'PyStringConcatBear',
+                'Use of explicit string concatenation with `+` '
+                'should be avoided.',
+                line=2, column=16, end_line=3, end_column=17, file='default')
+             ],
+            filename='default'
+            )


### PR DESCRIPTION
Detect use of explicit string concatenation in Python.
The bear checks if a line ends in a `+` and if so checks if the following line starts with a string enclosing character (', ", `).

Closes https://github.com/coala/coala-bears/issues/2434