### PR TITLE
HTTPSBear: Remove use of generic no cover

### DIFF
--- a/bears/general/HTTPSBear.py
+++ b/bears/general/HTTPSBear.py
@@ -66,7 +66,7 @@ class HTTPSBear(LocalBear):
 
             try:
                 https_code = https_response.status_code
-            except AttributeError:  # pragma: no cover
+            except AttributeError:
                 continue
 
             if not https_code or not 200 <= https_code < 300:

--- a/tests/general/HTTPSBearTest.py
+++ b/tests/general/HTTPSBearTest.py
@@ -107,3 +107,19 @@ class HTTPSBearTest(LocalBearTestHelper):
         with requests_mock.Mocker() as m:
             m.add_matcher(custom_matcher_https)
             self.check_validity(self.uut, test_link)
+
+    def test_request_exception(self):
+        test_link = """
+        http://httpbin.org/status/v200
+        """.splitlines()
+
+        with unittest.mock.patch(
+            'requests.head',
+            side_effect=requests.exceptions.RequestException,
+        ) as check:
+            self.check_validity(self.uut, test_link)
+            check.assert_called_with(
+                'https://httpbin.org/status/v200',
+                allow_redirects=False,
+                timeout=HTTPSBear.DEFAULT_TIMEOUT,
+            )


### PR DESCRIPTION
add test for RequestException

Closes https://github.com/coala/coala-bears/issues/2768

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
