### PR TITLE
Fix CommitBear coverage drop

### DIFF
--- a/bears/vcs/CommitBear.py
+++ b/bears/vcs/CommitBear.py
@@ -1,5 +1,7 @@
 import abc
 import logging
+import sys
+
 import nltk
 import re
 from contextlib import redirect_stdout
@@ -73,7 +75,7 @@ class _CommitBear(GlobalBear):
                 nltk.download([
                     'punkt',
                     'averaged_perceptron_tagger'
-                ])
+                ], print_error_to=sys.stdout)
                 type(self)._nltk_data_downloaded = True
 
     @classmethod


### PR DESCRIPTION
Fix coverage drop by rolling back nltk to 3.3

Fixes https://github.com/coala/coala-bears/issues/2788

nltk 3.4 was  released on the 17th. The coverage drop happened with https://github.com/coala/coala-bears/pull/2786 which was merged on Nov 17th. On my machine, using nltk 3.3 brings back coverage for 70 -> exit.

Line 70 is setting a lambda for `logger`, which would be passed to `redirect_stdout`. On the subsequent lines, nltk is called. Perhaps there are some changes in nltk 3.4 that broke this. 

I spent a couple of hours looking at the tests and couldn't find anything else that could have caused the coverage drop. I believe this is the likely culprit. 
<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
