### PR TITLE
GitRevertInspectBear: Remove use of no cover

### DIFF
--- a/bears/vcs/git/GitRevertInspectBear.py
+++ b/bears/vcs/git/GitRevertInspectBear.py
@@ -49,7 +49,7 @@ class GitRevertInspectBear(GlobalBear):
                                          'edit' %
                                          reverted_commit_sha)
         _, err = run_shell_command(create_expected_revert_commit)
-        if err:  # pragma: no cover
+        if err:
             self.warn('Cannot compare the modified files.')
             run_shell_command('git revert --abort')
             clean_inspect_revert_branch()


### PR DESCRIPTION
Add test case that that mocks an error. 

Closes https://github.com/coala/coala-bears/issues/2774


<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
