### PR TITLE
Add Windows coverage exceptions to reach 100%

### DIFF
--- a/bears/apertium/ApertiumLintBear.py
+++ b/bears/apertium/ApertiumLintBear.py
@@ -11,7 +11,7 @@ from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
                      r'(?P<origin>[^\n]+))\n[^:\n]+: (?P<line>\d+)',
         config_suffix='.json',
         severity_map={'Warning': RESULT_SEVERITY.MAJOR})
-class ApertiumLintBear:
+class ApertiumLintBear:  # pragma nt: no cover
     """
     `Apertium lint` is a python module that lints out irregular yet
     acceptable constructs that may creep into files involved in the

--- a/bears/c_languages/ArtisticStyleBear.py
+++ b/bears/c_languages/ArtisticStyleBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.DistributionRequirement import (
 @linter(executable='astyle',
         output_format='corrected',
         use_stdin=True)
-class ArtisticStyleBear:
+class ArtisticStyleBear:  # pragma nt: no cover
     """
     Artistic Style is a source code indenter, formatter,
     and beautifier for the C, C++, C++/CLI, Objective-C,

--- a/bears/c_languages/CPPCheckBear.py
+++ b/bears/c_languages/CPPCheckBear.py
@@ -15,7 +15,7 @@ from coalib.settings.Setting import typed_list
         severity_map={'error': RESULT_SEVERITY.MAJOR,
                       'warning': RESULT_SEVERITY.NORMAL,
                       'style': RESULT_SEVERITY.INFO})
-class CPPCheckBear:
+class CPPCheckBear:  # pragma nt: no cover
     """
     Report possible security weaknesses for C/C++.
     For more information, consult <https://github.com/danmar/cppcheck>.

--- a/bears/c_languages/CPPCleanBear.py
+++ b/bears/c_languages/CPPCleanBear.py
@@ -6,7 +6,7 @@ from coalib.settings.Setting import typed_list
 @linter(executable='cppclean',
         output_format='regex',
         output_regex=r'.+:(?P<line>\d+):(?P<message>.*)')
-class CPPCleanBear:
+class CPPCleanBear:  # pragma nt: no cover
     """
     Find problems in C++ source code that slow down development in large code
     bases. This includes finding unused code, among other features.

--- a/bears/c_languages/CSecurityBear.py
+++ b/bears/c_languages/CSecurityBear.py
@@ -20,7 +20,7 @@ from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
                                          'make sure the first line in the '
                                          'script is '
                                          '"#!/usr/bin/env python2".'))
-class CSecurityBear:
+class CSecurityBear:  # pragma nt: no cover
     """
     Report possible security weaknesses for C/C++.
 

--- a/bears/c_languages/CSharpLintBear.py
+++ b/bears/c_languages/CSharpLintBear.py
@@ -9,7 +9,7 @@ from dependency_management.requirements.DistributionRequirement import (
         output_format='regex',
         output_regex=r'.+\((?P<line>\d+),(?P<column>\d+)\): '
                      r'(?P<severity>error|warning) \w+: (?P<message>.+)')
-class CSharpLintBear:
+class CSharpLintBear:  # pragma nt: no cover
     """
     Checks C# code for syntactical correctness using the ``mcs`` compiler.
     """

--- a/bears/c_languages/ClangBear.py
+++ b/bears/c_languages/ClangBear.py
@@ -21,14 +21,14 @@ def clang_available(cls):
     if get_distribution('libclang-py3').version != '3.4.0':
         return ClangBear.name + ' requires clang 3.4.0'
 
-    try:
+    try:  # pragma nt: no cover
         Index.create()
         return True
     except LibclangError as error:  # pragma: no cover
         return str(error)
 
 
-def diff_from_clang_fixit(fixit, file):
+def diff_from_clang_fixit(fixit, file):  # pragma nt: no cover
     """
     Creates a ``Diff`` object from a given clang fixit and the file contents.
 
@@ -65,7 +65,7 @@ def sourcerange_from_clang_range(clang_range):
                                    clang_range.end.column)
 
 
-class ClangBear(LocalBear):
+class ClangBear(LocalBear):  # pragma nt: no cover
     LANGUAGES = {'C', 'CPP', 'Objective-C', 'Objective-CPP', 'OpenMP',
                  'OpenCL', 'CUDA'}
     # Depends on libclang-py3, which is a dependency of coala

--- a/bears/c_languages/ClangComplexityBear.py
+++ b/bears/c_languages/ClangComplexityBear.py
@@ -8,7 +8,7 @@ from bears.c_languages.ClangBear import (
 )
 
 
-class ClangComplexityBear(LocalBear):
+class ClangComplexityBear(LocalBear):  # pragma nt: no cover
     """
     Calculates cyclomatic complexity of each function and displays it to the
     user.

--- a/bears/c_languages/GNUIndentBear.py
+++ b/bears/c_languages/GNUIndentBear.py
@@ -13,7 +13,7 @@ from dependency_management.requirements.DistributionRequirement import (
         use_stdin=True,
         output_format='corrected',
         result_message='Indentation can be improved.')
-class GNUIndentBear:
+class GNUIndentBear:  # pragma nt: no cover
     """
     This bear checks and corrects spacing and indentation via the well known
     Indent utility.

--- a/bears/c_languages/codeclone_detection/ClangASTPrintBear.py
+++ b/bears/c_languages/codeclone_detection/ClangASTPrintBear.py
@@ -4,7 +4,7 @@ from bears.c_languages.ClangBear import clang_available, ClangBear
 from coalib.bears.GlobalBear import GlobalBear
 
 
-class ClangASTPrintBear(GlobalBear):
+class ClangASTPrintBear(GlobalBear):  # pragma nt: no cover
     check_prerequisites = classmethod(clang_available)
     LANGUAGES = ClangBear.LANGUAGES
     REQUIREMENTS = ClangBear.REQUIREMENTS

--- a/bears/c_languages/codeclone_detection/ClangCloneDetectionBear.py
+++ b/bears/c_languages/codeclone_detection/ClangCloneDetectionBear.py
@@ -6,7 +6,7 @@ from coalib.results.Result import Result
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 
-class ClangCloneDetectionBear(GlobalBear):
+class ClangCloneDetectionBear(GlobalBear):  # pragma nt: no cover
     check_prerequisites = classmethod(clang_available)
     LANGUAGES = ClangBear.LANGUAGES
     REQUIREMENTS = ClangBear.REQUIREMENTS

--- a/bears/c_languages/codeclone_detection/ClangCountVectorCreator.py
+++ b/bears/c_languages/codeclone_detection/ClangCountVectorCreator.py
@@ -5,7 +5,7 @@ from bears.c_languages.codeclone_detection.ClangCountingConditions import (
 from bears.c_languages.codeclone_detection.CountVector import CountVector
 
 
-class ClangCountVectorCreator:
+class ClangCountVectorCreator:  # pragma nt: no cover
     """
     This object uses clang to create a count vector for each function for given
     counting conditions. The counting conditions are clang specific and they

--- a/bears/c_languages/codeclone_detection/ClangCountingConditions.py
+++ b/bears/c_languages/codeclone_detection/ClangCountingConditions.py
@@ -10,7 +10,7 @@ from clang.cindex import CursorKind
 from coalib.misc.Enum import enum
 
 
-def is_function_declaration(cursor):
+def is_function_declaration(cursor):  # pragma nt: no cover
     """
     Checks if the given clang cursor is a function declaration.
 
@@ -20,7 +20,7 @@ def is_function_declaration(cursor):
     return cursor.kind == CursorKind.FUNCTION_DECL
 
 
-def get_identifier_name(cursor):
+def get_identifier_name(cursor):  # pragma nt: no cover
     """
     Retrieves the identifier name from the given clang cursor.
 
@@ -30,7 +30,7 @@ def get_identifier_name(cursor):
     return cursor.displayname
 
 
-def is_literal(cursor):
+def is_literal(cursor):  # pragma nt: no cover
     """
     :param cursor: A clang cursor from the AST.
     :return:       True if the cursor is a literal of any kind..
@@ -45,7 +45,7 @@ def is_literal(cursor):
                            CursorKind.CXX_NULL_PTR_LITERAL_EXPR]
 
 
-def is_reference(cursor):
+def is_reference(cursor):  # pragma nt: no cover
     """
     Determines if the cursor is a reference to something, i.e. an identifier
     of a function or variable.
@@ -58,7 +58,7 @@ def is_reference(cursor):
                            CursorKind.DECL_REF_EXPR]
 
 
-def _stack_contains_kind(stack, kind):
+def _stack_contains_kind(stack, kind):  # pragma nt: no cover
     """
     Checks if a cursor with the given kind is within the stack.
 
@@ -74,7 +74,7 @@ def _stack_contains_kind(stack, kind):
     return False
 
 
-def _is_nth_child_of_kind(stack, allowed_nums, kind):
+def _is_nth_child_of_kind(stack, allowed_nums, kind):  # pragma nt: no cover
     """
     Checks if the stack contains a cursor which is of the given kind and the
     stack also has a child of this element which number is in the allowed_nums
@@ -100,7 +100,7 @@ def _is_nth_child_of_kind(stack, allowed_nums, kind):
     return count
 
 
-def is_function(stack):
+def is_function(stack):  # pragma nt: no cover
     """
     Checks if the cursor on top of the stack is used as a method or as a
     variable.
@@ -115,7 +115,7 @@ def is_function(stack):
 FOR_POSITION = enum('UNKNOWN', 'INIT', 'COND', 'INC', 'BODY')
 
 
-def _get_position_in_for_tokens(tokens, position):
+def _get_position_in_for_tokens(tokens, position):  # pragma nt: no cover
     """
     Retrieves the semantic position of the given position in a for loop. It
     operates under the assumptions that the given tokens represent a for loop
@@ -161,7 +161,7 @@ def _get_position_in_for_tokens(tokens, position):
     return FOR_POSITION.UNKNOWN  # pragma: no cover
 
 
-def _get_positions_in_for_loop(stack):
+def _get_positions_in_for_loop(stack):  # pragma nt: no cover
     """
     Investigates all FOR_STMT objects in the stack and checks for each in
     what position the given cursor is.
@@ -180,7 +180,7 @@ def _get_positions_in_for_loop(stack):
     return results
 
 
-def _get_binop_operator(cursor):
+def _get_binop_operator(cursor):  # pragma nt: no cover
     """
     Returns the operator token of a binary operator cursor.
 
@@ -203,7 +203,7 @@ def _get_binop_operator(cursor):
     return None  # pragma: no cover
 
 
-def _stack_contains_operators(stack, operators):
+def _stack_contains_operators(stack, operators):  # pragma nt: no cover
     """
     Checks if one of the given operators is within the stack.
 
@@ -233,7 +233,7 @@ ADV_ASSIGNMENT_OPERATORS = [op + '=' for op in ARITH_BINARY_OPERATORS]
 ASSIGNMENT_OPERATORS = ['='] + ADV_ASSIGNMENT_OPERATORS
 
 
-def in_sum(stack):
+def in_sum(stack):  # pragma nt: no cover
     """
     A counting condition returning true if the variable is used in a sum
     statement, i.e. within the operators +, - and their associated compound
@@ -242,7 +242,7 @@ def in_sum(stack):
     return _stack_contains_operators(stack, ['+', '-', '+=', '-='])
 
 
-def in_product(stack):
+def in_product(stack):  # pragma nt: no cover
     """
     A counting condition returning true if the variable is used in a product
     statement, i.e. within the operators \*, /, % and their associated compound
@@ -251,7 +251,7 @@ def in_product(stack):
     return _stack_contains_operators(stack, ['*', '/', '%', '*=', '/=', '%='])
 
 
-def in_binary_operation(stack):
+def in_binary_operation(stack):  # pragma nt: no cover
     """
     A counting condition returning true if the variable is used in a binary
     operation, i.e. within the operators \|, & and their associated compound
@@ -260,7 +260,7 @@ def in_binary_operation(stack):
     return _stack_contains_operators(stack, ['&', '|', '&=', '|='])
 
 
-def member_accessed(stack):
+def member_accessed(stack):  # pragma nt: no cover
     """
     Returns true if a member of the cursor is accessed or the cursor is the
     accessed member.
@@ -269,21 +269,21 @@ def member_accessed(stack):
 
 
 # pylint: disabled=unused-argument
-def used(stack):
+def used(stack):  # pragma nt: no cover
     """
     Returns true.
     """
     return True
 
 
-def returned(stack):
+def returned(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is used in a return statement.
     """
     return _stack_contains_kind(stack, CursorKind.RETURN_STMT)
 
 
-def is_inc_or_dec(stack):
+def is_inc_or_dec(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is inc- or decremented.
     """
@@ -296,7 +296,7 @@ def is_inc_or_dec(stack):
     return False
 
 
-def is_condition(stack):
+def is_condition(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is used as a condition.
     """
@@ -307,7 +307,7 @@ def is_condition(stack):
             FOR_POSITION.COND in _get_positions_in_for_loop(stack))
 
 
-def in_condition(stack):
+def in_condition(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is in the body of one condition.
     """
@@ -318,14 +318,14 @@ def in_condition(stack):
              _is_nth_child_of_kind(stack, [0], CursorKind.CASE_STMT) == 0))
 
 
-def in_second_level_condition(stack):
+def in_second_level_condition(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is in the body of two nested conditions.
     """
     return _is_nth_child_of_kind(stack, [1, 2], CursorKind.IF_STMT) == 2
 
 
-def in_third_level_condition(stack):
+def in_third_level_condition(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is in the body of three or more nested
     conditions.
@@ -333,7 +333,7 @@ def in_third_level_condition(stack):
     return _is_nth_child_of_kind(stack, [1, 2], CursorKind.IF_STMT) > 2
 
 
-def is_assignee(stack):
+def is_assignee(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is assigned something.
     """
@@ -354,7 +354,7 @@ def is_assignee(stack):
     return is_inc_or_dec(stack)
 
 
-def is_assigner(stack):
+def is_assigner(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is used for an assignment on the RHS.
     """
@@ -377,7 +377,7 @@ def is_assigner(stack):
     return is_inc_or_dec(stack)
 
 
-def _loop_level(stack):
+def _loop_level(stack):  # pragma nt: no cover
     """
     Investigates the stack to determine the loop level.
 
@@ -390,35 +390,35 @@ def _loop_level(stack):
             _is_nth_child_of_kind(stack, [1], CursorKind.WHILE_STMT))
 
 
-def loop_content(stack):
+def loop_content(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is within a first level loop.
     """
     return _loop_level(stack) == 1
 
 
-def second_level_loop_content(stack):
+def second_level_loop_content(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is within a second level loop.
     """
     return _loop_level(stack) == 2
 
 
-def third_level_loop_content(stack):
+def third_level_loop_content(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is within a third (or higher) level loop.
     """
     return _loop_level(stack) > 2
 
 
-def is_param(stack):
+def is_param(stack):  # pragma nt: no cover
     """
     Returns true if the cursor on top is a parameter declaration.
     """
     return stack[-1][0].kind == CursorKind.PARM_DECL
 
 
-def is_called(stack):
+def is_called(stack):  # pragma nt: no cover
     """
     Yields true if the cursor is a function that is called. (Function pointers
     are counted too.)
@@ -427,7 +427,7 @@ def is_called(stack):
             is_function(stack))
 
 
-def is_call_param(stack):
+def is_call_param(stack):  # pragma nt: no cover
     """
     Yields true if the cursor is a parameter to another function.
     """
@@ -455,7 +455,7 @@ condition_dict = {'used': used,
                   'member_accessed': member_accessed}
 
 
-def counting_condition(value):
+def counting_condition(value):  # pragma nt: no cover
     """
     This is a custom converter to convert a setting from coala into counting
     condition function objects for this bear only.

--- a/bears/c_languages/codeclone_detection/ClangFunctionDifferenceBear.py
+++ b/bears/c_languages/codeclone_detection/ClangFunctionDifferenceBear.py
@@ -57,7 +57,7 @@ member_accessed"""))
                    'differences',
                    'count_matrices',
                    'message')
-class ClangFunctionDifferenceResult(HiddenResult):
+class ClangFunctionDifferenceResult(HiddenResult):  # pragma nt: no cover
 
     @enforce_signature
     def __init__(self, origin,
@@ -73,7 +73,7 @@ def get_difference(function_pair,
                    count_matrices,
                    average_calculation,
                    poly_postprocessing,
-                   exp_postprocessing):
+                   exp_postprocessing):  # pragma nt: no cover
     """
     Retrieves the difference between two functions using the munkres algorithm.
 
@@ -104,7 +104,7 @@ def get_difference(function_pair,
                               exp_postprocessing))
 
 
-class ClangFunctionDifferenceBear(GlobalBear):
+class ClangFunctionDifferenceBear(GlobalBear):  # pragma nt: no cover
     check_prerequisites = classmethod(clang_available)
     LANGUAGES = ClangBear.LANGUAGES
     REQUIREMENTS = ClangBear.REQUIREMENTS | {PipRequirement('munkres3', '1.0')}

--- a/bears/c_languages/codeclone_detection/CloneDetectionRoutines.py
+++ b/bears/c_languages/codeclone_detection/CloneDetectionRoutines.py
@@ -11,7 +11,7 @@ from bears.c_languages.codeclone_detection.CountVector import CountVector
 munkres = Munkres()
 
 
-def exclude_function(count_matrix):
+def exclude_function(count_matrix):  # pragma nt: no cover
     """
     Determines heuristically whether or not it makes sense for clone
     detection to take this function into account.
@@ -40,7 +40,7 @@ def get_count_matrices(count_vector_creator,
                        filenames,
                        progress_callback,
                        base_path,
-                       extra_include_paths):
+                       extra_include_paths):  # pragma nt: no cover
     """
     Retrieves matrices holding count vectors for all variables for all
     functions in the given file.
@@ -75,7 +75,7 @@ def get_count_matrices(count_vector_creator,
     return result
 
 
-def pad_count_vectors(cm1, cm2):
+def pad_count_vectors(cm1, cm2):  # pragma nt: no cover
     """
     Pads the smaller count matrix with zeroed count vectors.
 
@@ -111,14 +111,14 @@ def relative_difference(difference, maxabs):
     return difference/maxabs
 
 
-def average(lst):
+def average(lst):  # pragma nt: no cover
     return sum(lst)/len(lst)
 
 
 def get_difference(matching_iterator,
                    average_calculation,
                    poly_postprocessing,
-                   exp_postprocessing):
+                   exp_postprocessing):  # pragma nt: no cover
     """
     Retrieves the difference value for the matched function represented by the
     given matches.
@@ -167,7 +167,7 @@ def compare_functions(cm1,
                       cm2,
                       average_calculation=False,
                       poly_postprocessing=True,
-                      exp_postprocessing=False):
+                      exp_postprocessing=False):  # pragma nt: no cover
     """
     Compares the functions represented by the given count matrices.
 

--- a/bears/cmake/CMakeLintBear.py
+++ b/bears/cmake/CMakeLintBear.py
@@ -6,7 +6,7 @@ from coalib.settings.Setting import path
 @linter(executable='cmakelint',
         output_format='regex',
         output_regex=r'.+:(?P<line>\d+): (?P<message>.*)')
-class CMakeLintBear:
+class CMakeLintBear:  # pragma nt: no cover
     """
     Check CMake code for syntactical or formatting issues.
 

--- a/bears/coffee_script/CoffeeLintBear.py
+++ b/bears/coffee_script/CoffeeLintBear.py
@@ -10,7 +10,7 @@ from coala_utils.param_conversion import negate
 
 @linter(executable='coffeelint',
         use_stdin=True)
-class CoffeeLintBear:
+class CoffeeLintBear:  # pragma nt: no cover
     """
     Check CoffeeScript code for a clean and consistent style.
 

--- a/bears/configfiles/DockerfileLintBear.py
+++ b/bears/configfiles/DockerfileLintBear.py
@@ -7,7 +7,7 @@ from coalib.results.Result import Result
 
 
 @linter(executable='dockerfile_lint')
-class DockerfileLintBear:
+class DockerfileLintBear:  # pragma nt: no cover
     """
     Checks file syntax as well as arbitrary semantics and best practice
     in Dockerfiles. It also checks LABEL rules against docker images.

--- a/bears/configfiles/PuppetLintBear.py
+++ b/bears/configfiles/PuppetLintBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.GemRequirement import GemRequirement
         output_format='regex',
         output_regex=r'(?P<line>\d+):(?P<column>\d+):'
                      r'(?P<severity>warning|error):(?P<message>.+)')
-class PuppetLintBear:
+class PuppetLintBear:  # pragma nt: no cover
     '''
     Check and correct puppet configuration files using ``puppet-lint``.
 

--- a/bears/configfiles/TOMLBear.py
+++ b/bears/configfiles/TOMLBear.py
@@ -8,7 +8,7 @@ from dependency_management.requirements.GoRequirement import GoRequirement
         output_regex=r"Error in '.*': "
                      r'Near line (?P<line>\d+) '
                      r"\(last key parsed '.*'\): (?P<message>.*)")
-class TOMLBear:
+class TOMLBear:  # pragma nt: no cover
     """
     Checks the code for formatting in ``TOML`` documents and prints
     each key's type. This is done using ``tomlv`` utility.

--- a/bears/css/CSSAutoPrefixBear.py
+++ b/bears/css/CSSAutoPrefixBear.py
@@ -7,7 +7,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         result_message='Add vendor prefixes to CSS rules.',
         prerequisite_check_command=('postcss', '--use', 'autoprefixer'),
         prerequisite_check_fail_message='Autoprefixer is not installed.')
-class CSSAutoPrefixBear:
+class CSSAutoPrefixBear:  # pragma nt: no cover
     """
     This bear adds vendor prefixes to CSS rules using ``autoprefixer`` utility.
     """

--- a/bears/css/CSSCombBear.py
+++ b/bears/css/CSSCombBear.py
@@ -9,7 +9,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         output_format='corrected',
         use_stdin=True,
         result_message='The text does not comply to the set style.')
-class CSSCombBear:
+class CSSCombBear:  # pragma nt: no cover
     """
     CSScomb is a coding style formatter for CSS. You can easily write your own
     configuration to make your style sheets beautiful and consistent.

--- a/bears/css/CSSLintBear.py
+++ b/bears/css/CSSLintBear.py
@@ -7,7 +7,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         output_regex=r'.+: *(?:line (?P<line>\d+), '
                      r'col (?P<column>\d+), )?(?P<severity>Error|Warning) - '
                      r'(?P<message>.*)')
-class CSSLintBear:
+class CSSLintBear:  # pragma nt: no cover
     """
     Check code for syntactical or semantical problems that might lead to
     problems or inefficiencies.

--- a/bears/css/StyleLintBear.py
+++ b/bears/css/StyleLintBear.py
@@ -8,7 +8,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         output_regex=r'\s*(?P<filename>.+)\s*(?P<line>\d+):(?P<column>\d+)\s*'
                      r'\D\s*(?P<message>.+)',
         config_suffix='.json')
-class StyleLintBear:
+class StyleLintBear:  # pragma nt: no cover
     """
     Checks the code with stylelint. This will run stylelint over each file
     separately.

--- a/bears/csv/CSVLintBear.py
+++ b/bears/csv/CSVLintBear.py
@@ -6,7 +6,7 @@ from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 
 @linter(executable='csvlint')
-class CSVLintBear:
+class CSVLintBear:  # pragma nt: no cover
     """
     Verifies using ``csvlint`` if ``.csv`` files are valid CSV or not.
     """

--- a/bears/dart/DartLintBear.py
+++ b/bears/dart/DartLintBear.py
@@ -7,7 +7,7 @@ from dependency_management.requirements.DistributionRequirement import (
         output_format='regex',
         output_regex=r'\[(?P<severity>error|warning)\] (?P<message>.+)\('
                      r'.+, line (?P<line>\d+), col (?P<column>\d+)\)')
-class DartLintBear:
+class DartLintBear:  # pragma nt: no cover
     """
     Checks the code with ``dart-linter``.
 

--- a/bears/elm/ElmLintBear.py
+++ b/bears/elm/ElmLintBear.py
@@ -29,9 +29,9 @@ class ElmLintBear:
             return ('elm-format is missing. Download it from '
                     'https://github.com/avh4/elm-format/blob/master/README.md'
                     '#for-elm-018 and put it into your PATH.')
-        else:
+        else:  # pragma nt: no cover
             return True
 
     @staticmethod
-    def create_arguments(filename, file, config_file):
+    def create_arguments(filename, file, config_file):  # pragma nt: no cover
         return filename, '--yes'

--- a/bears/general/CPDBear.py
+++ b/bears/general/CPDBear.py
@@ -8,7 +8,7 @@ from coalib.results.SourceRange import SourceRange
 from coalib.settings.Setting import language
 
 
-class CPDBear(GlobalBear):
+class CPDBear(GlobalBear):  # pragma nt: no cover
 
     language_dict = {'C#': 'cs',
                      'CPP': 'cpp',

--- a/bears/general/LicenseCheckBear.py
+++ b/bears/general/LicenseCheckBear.py
@@ -7,7 +7,7 @@ from dependency_management.requirements.DistributionRequirement import (
         output_format='regex',
         output_regex=r'.*: .*UNKNOWN$',
         result_message='No license found.')
-class LicenseCheckBear:
+class LicenseCheckBear:  # pragma nt: no cover
     """
     Attempts to check the given file for a license, by searching the start
     of the file for text belonging to various licenses.

--- a/bears/general/TextLintBear.py
+++ b/bears/general/TextLintBear.py
@@ -11,7 +11,7 @@ from dependency_management.requirements.PipRequirement import PipRequirement
         output_regex=r'(?P<line>\d+):(?P<column>\d+)(?:\s|\u2713)*'
                      r'(?P<severity>error|warning)\s+(?P<message>.+?)'
                      r'(?:  .*|\n|$)')
-class TextLintBear:
+class TextLintBear:  # pragma nt: no cover
     """
     The pluggable linting tool for text and Markdown. It is similar to ESLint,
     but covers natural language instead.

--- a/bears/gherkin/GherkinLintBear.py
+++ b/bears/gherkin/GherkinLintBear.py
@@ -11,7 +11,7 @@ _setting_map = {True: 'on',
         use_stderr=True,
         use_stdout=False,
         global_bear=True)
-class GherkinLintBear:
+class GherkinLintBear:  # pragma nt: no cover
     """
     Use Gherkin to run linting on feature files
     """

--- a/bears/go/GoErrCheckBear.py
+++ b/bears/go/GoErrCheckBear.py
@@ -8,7 +8,7 @@ from coalib.settings.Setting import typed_list
         output_regex=r'[^:]+:(?P<line>\d+):'
                      r'(?P<column>\d+)\s*(?P<message>.*)',
         result_message='This function call has an unchecked error.')
-class GoErrCheckBear:
+class GoErrCheckBear:  # pragma nt: no cover
 
     """
     Checks the code for all function calls that have unchecked errors.

--- a/bears/go/GoImportsBear.py
+++ b/bears/go/GoImportsBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.GoRequirement import GoRequirement
         use_stdin=True,
         output_format='corrected',
         result_message='Imports need to be added/removed.')
-class GoImportsBear:
+class GoImportsBear:  # pragma nt: no cover
     """
     Adds/Removes imports to Go code for missing imports.
     """

--- a/bears/go/GoLintBear.py
+++ b/bears/go/GoLintBear.py
@@ -7,7 +7,7 @@ from dependency_management.requirements.GoRequirement import GoRequirement
 @linter(executable='golint',
         output_format='regex',
         output_regex=r'.+:(?P<line>\d+):(?P<column>\d+): (?P<message>.*)')
-class GoLintBear:
+class GoLintBear:  # pragma nt: no cover
     """
     Checks the code using ``golint``. This will run golint over each file
     separately.

--- a/bears/go/GoReturnsBear.py
+++ b/bears/go/GoReturnsBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.GoRequirement import GoRequirement
         use_stdin=True,
         output_format='corrected',
         result_message='Imports or returns need to be added/removed.')
-class GoReturnsBear:
+class GoReturnsBear:  # pragma nt: no cover
     """
     Proposes corrections of Go code using ``goreturns``.
     """

--- a/bears/go/GoTypeBear.py
+++ b/bears/go/GoTypeBear.py
@@ -7,7 +7,7 @@ from dependency_management.requirements.GoRequirement import GoRequirement
         use_stderr=True,
         output_format='regex',
         output_regex=r'.+:(?P<line>\d+):(?P<column>\d+): *(?P<message>.*)')
-class GoTypeBear:
+class GoTypeBear:  # pragma nt: no cover
     """
     Checks the code using ``gotype``. This will run ``gotype`` over each file
     separately.

--- a/bears/haml/HAMLLintBear.py
+++ b/bears/haml/HAMLLintBear.py
@@ -10,7 +10,7 @@ from dependency_management.requirements.GemRequirement import GemRequirement
         output_format='regex',
         output_regex=r'(?P<line>\d+) \[(?P<severity>W|E)\] '
                      r'(?P<message>.*)')
-class HAMLLintBear:
+class HAMLLintBear:  # pragma nt: no cover
     """
     Uses ``haml-lint`` to perform HAML-specific style and lint checks to ensure
     clean and readable HAML code.

--- a/bears/haskell/GhcModBear.py
+++ b/bears/haskell/GhcModBear.py
@@ -11,7 +11,7 @@ from dependency_management.requirements.DistributionRequirement import (
         output_format='regex',
         output_regex=r'.+:(?P<line>\d+):(?P<column>\d+):'
                      r'(?P<message>.+)')
-class GhcModBear:
+class GhcModBear:  # pragma nt: no cover
     """
     Syntax checking with ``ghc`` for Haskell files.
 

--- a/bears/haskell/HaskellLintBear.py
+++ b/bears/haskell/HaskellLintBear.py
@@ -13,7 +13,7 @@ from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 
 @linter(executable='hlint')
-class HaskellLintBear:
+class HaskellLintBear:  # pragma nt: no cover
     """
     Check Haskell code for possible problems. This bear can propose patches for
     using alternative functions, simplifying code and removing redundancies.

--- a/bears/hypertext/BootLintBear.py
+++ b/bears/hypertext/BootLintBear.py
@@ -7,7 +7,7 @@ from coalib.settings.Setting import typed_list
         output_format='regex',
         output_regex=r'.+:(?P<line>\d*):(?P<column>\d*) (?P<severity>.)\d+ '
                      r'(?P<message>.+)')
-class BootLintBear:
+class BootLintBear:  # pragma nt: no cover
     """
     Raise several common HTML mistakes in html files that are using
     Bootstrap in a fairly "vanilla" way. Vanilla Bootstrap's components/widgets

--- a/bears/hypertext/HTMLHintBear.py
+++ b/bears/hypertext/HTMLHintBear.py
@@ -9,7 +9,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         output_format='regex',
         output_regex=r'(?P<filename>.+):(?P<line>\d+):(?P<column>\d+):\s*'
                      r'(?P<message>.+) \[(?P<severity>error|warning).+\]')
-class HTMLHintBear:
+class HTMLHintBear:  # pragma nt: no cover
     """
     Checks HTML code with ``htmlhint`` for possible problems. Attempts to catch
     little mistakes and enforces a code style guide on HTML files.

--- a/bears/java/CheckstyleBear.py
+++ b/bears/java/CheckstyleBear.py
@@ -94,7 +94,7 @@ class CheckstyleBear:
             # Checkstyle included these two rulesets since version 6.2
             # Locate the file as an absolute resource into the checkstyle jar
             checkstyle_configs = '/%s_checks.xml' % checkstyle_configs
-        elif checkstyle_configs in _online_styles:
+        elif checkstyle_configs in _online_styles:  # pragma nt: no cover
             checkstyle_configs = self.download_cached_file(
                 _online_styles[checkstyle_configs],
                 checkstyle_configs + '.xml')

--- a/bears/java/InferBear.py
+++ b/bears/java/InferBear.py
@@ -5,7 +5,7 @@ from coalib.bearlib.abstractions.Linter import linter
         output_format='regex',
         output_regex=r'.+:(?P<line>\d+): (?P<severity>error|warning): '
                      r'(?P<message>.*)')
-class InferBear:
+class InferBear:  # pragma nt: no cover
     """
     Checks the code with ``infer``.
     """

--- a/bears/java/JavaPMDBear.py
+++ b/bears/java/JavaPMDBear.py
@@ -48,7 +48,8 @@ class JavaPMDBear:
                          check_optimizations: bool = False,
                          check_strings: bool = False,
                          allow_unnecessary_code: bool = False,
-                         allow_unused_code: bool = False):
+                         allow_unused_code: bool = False,
+                         ):  # pragma nt: no cover
         """
         :param check_best_practices:
             Checks for best practices.

--- a/bears/js/ESLintBear.py
+++ b/bears/js/ESLintBear.py
@@ -12,7 +12,7 @@ from coalib.settings.Setting import language
 @linter(executable='eslint',
         use_stdin=True,
         use_stderr=True)
-class ESLintBear:
+class ESLintBear:  # pragma nt: no cover
     """
     Check JavaScript and JSX code for style issues and semantic errors.
 

--- a/bears/js/HappinessLintBear.py
+++ b/bears/js/HappinessLintBear.py
@@ -5,7 +5,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
 @linter(executable='happiness',
         output_format='regex',
         output_regex=r'\s.+:(?P<line>\d+):(?P<column>\d+):(?P<message>.+)')
-class HappinessLintBear:
+class HappinessLintBear:  # pragma nt: no cover
     """
     Checks JavaScript files for semantic and syntax errors using ``happiness``.
 

--- a/bears/js/JSComplexityBear.py
+++ b/bears/js/JSComplexityBear.py
@@ -9,7 +9,7 @@ from coalib.results.Result import Result
 
 
 @linter(executable='cr')
-class JSComplexityBear:
+class JSComplexityBear:  # pragma nt: no cover
     """
     Calculates cyclomatic complexity using ``cr``, the command line utility
     provided by the NodeJS module ``complexity-report``.

--- a/bears/js/JSHintBear.py
+++ b/bears/js/JSHintBear.py
@@ -6,14 +6,14 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
 from coala_utils.param_conversion import negate
 
 
-def bool_or_str(value):
+def bool_or_str(value):  # pragma nt: no cover
     try:
         return bool(value)
     except ValueError:
         return str(value)
 
 
-def bool_or_int(value):
+def bool_or_int(value):  # pragma nt: no cover
     try:
         return bool(value)
     except ValueError:
@@ -24,7 +24,7 @@ def bool_or_int(value):
         output_format='regex',
         output_regex=r'.+?: line (?P<line>\d+), col (?P<column>\d+), '
                      r'(?P<message>.+) \((?P<severity>[EWI])\d+\)')
-class JSHintBear:
+class JSHintBear:  # pragma nt: no cover
     """
     Detect errors and potential problems in JavaScript code and to enforce
     appropriate coding conventions. For example, problems like syntax errors,

--- a/bears/js/JSStandardBear.py
+++ b/bears/js/JSStandardBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         output_format='regex',
         output_regex=r'\s*[^:]+:(?P<line>\d+):(?P<column>\d+):'
                      r'\s*(?P<message>.+)')
-class JSStandardBear:
+class JSStandardBear:  # pragma nt: no cover
     """
     One JavaScript Style to Rule Them All.
 

--- a/bears/js/PrettierLintBear.py
+++ b/bears/js/PrettierLintBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
 @linter(executable='prettier',
         use_stdout=True,
         use_stderr=True)
-class PrettierLintBear:
+class PrettierLintBear:  # pragma nt: no cover
     """
     Formats JavaScript, JSX, Flow, TypeScript, CSS, Less, SCSS, JSON, GraphQL,
     Vue, Markdown files according to opinionated code format

--- a/bears/julia/JuliaLintBear.py
+++ b/bears/julia/JuliaLintBear.py
@@ -15,7 +15,7 @@ from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
         prerequisite_check_fail_message='Lint package not installed. Run '
                                         '`Pkg.add("Lint")` from Julia to '
                                         'install Lint.')
-class JuliaLintBear:
+class JuliaLintBear:  # pragma nt: no cover
     """
     Provide analysis related to common bugs and potential issues in Julia like
     dead code, undefined variable usage, duplicate keys in dicts, incorrect

--- a/bears/latex/LatexLintBear.py
+++ b/bears/latex/LatexLintBear.py
@@ -7,7 +7,7 @@ from dependency_management.requirements.DistributionRequirement import (
         output_format='regex',
         output_regex=r'(?P<severity>Error|Warning) \d+ in .+ line '
                      r'(?P<line>\d+): (?P<message>.*)')
-class LatexLintBear:
+class LatexLintBear:  # pragma nt: no cover
     """
     Checks the code with ``chktex``.
     """

--- a/bears/lua/LuaLintBear.py
+++ b/bears/lua/LuaLintBear.py
@@ -9,7 +9,7 @@ from dependency_management.requirements.LuarocksRequirement import (
         output_regex=r'stdin:(?P<line>\d+):(?P<column>\d+)-'
                      r'(?P<end_column>\d+): '
                      r'\((?P<severity>[WE])(?P<origin>\d+)\) (?P<message>.+)')
-class LuaLintBear:
+class LuaLintBear:  # pragma nt: no cover
     """
     Check Lua code for possible semantic problems, like unused code.
 

--- a/bears/markdown/MarkdownBear.py
+++ b/bears/markdown/MarkdownBear.py
@@ -10,7 +10,7 @@ from coalib.bearlib import deprecate_settings
 @linter(executable='remark',
         use_stdout=True,
         use_stderr=True)
-class MarkdownBear:
+class MarkdownBear:  # pragma nt: no cover
     """
     Check and correct Markdown style violations automatically.
 

--- a/bears/natural_language/AlexBear.py
+++ b/bears/natural_language/AlexBear.py
@@ -10,7 +10,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         output_regex=r'(?P<line>\d+):(?P<column>\d+)-(?P<end_line>\d+):'
                      r'(?P<end_column>\d+)\s+(?P<severity>warning)\s+'
                      r'(?P<message>.+)')
-class AlexBear:
+class AlexBear:  # pragma nt: no cover
     """
     Checks the markdown file with Alex - Catch insensitive, inconsiderate
     writing.

--- a/bears/natural_language/SpellCheckBear.py
+++ b/bears/natural_language/SpellCheckBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.PipRequirement import PipRequirement
         use_stderr=True,
         output_format='regex',
         output_regex=r'.*:(?P<line>.\d*):\s*(?P<message>.*)')
-class SpellCheckBear:
+class SpellCheckBear:  # pragma nt: no cover
     """
     Lints files to check for incorrect spellings using ``scspell``.
 

--- a/bears/natural_language/WriteGoodLintBear.py
+++ b/bears/natural_language/WriteGoodLintBear.py
@@ -10,7 +10,7 @@ from coala_utils.param_conversion import negate
         output_regex=r'(?P<message>.*)\s*on\s*line\s*(?P<line>\d+)\s*at\s'
                      r'column\s*(?P<column>\d+)'
         )
-class WriteGoodLintBear:
+class WriteGoodLintBear:  # pragma nt: no cover
     """
     Lints the text files using ``write-good`` for improving proses.
 

--- a/bears/php/PHPCodeSnifferBear.py
+++ b/bears/php/PHPCodeSnifferBear.py
@@ -13,7 +13,7 @@ from dependency_management.requirements.ComposerRequirement import (
         config_suffix='.xml',
         output_regex=r'.+:(?P<line>\d+):(?P<column>\d+): '
                      r'\w+ - (?P<message>.+)')
-class PHPCodeSnifferBear:
+class PHPCodeSnifferBear:  # pragma nt: no cover
     """
     Ensures that your PHP, JavaScript or CSS code remains clean and consistent.
 

--- a/bears/php/PHPLintBear.py
+++ b/bears/php/PHPLintBear.py
@@ -10,7 +10,7 @@ from dependency_management.requirements.DistributionRequirement import (
                      r'.* on line (?P<line>\d+)',
         severity_map={'Parse': RESULT_SEVERITY.MAJOR,
                       'Fatal': RESULT_SEVERITY.MAJOR})
-class PHPLintBear:
+class PHPLintBear:  # pragma nt: no cover
     """
     Checks the code with ``php -l``. This runs it on each file separately.
     """

--- a/bears/php/PHPMessDetectorBear.py
+++ b/bears/php/PHPMessDetectorBear.py
@@ -11,7 +11,7 @@ from dependency_management.requirements.ComposerRequirement import (
 @linter(executable='phpmd',
         output_format='regex',
         output_regex=r':(?P<line>\d+)\s*(?P<message>.*)')
-class PHPMessDetectorBear:
+class PHPMessDetectorBear:  # pragma nt: no cover
     """
     The bear takes a given PHP source code base and looks for several
     potential problems within that source. These problems can be things like:

--- a/bears/pug/PugLintBear.py
+++ b/bears/pug/PugLintBear.py
@@ -11,7 +11,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         output_regex=r'(?P<line>\d+):?(?P<column>\d+)? (?P<message>.+)',
         use_stdout=False,
         use_stderr=True)
-class PugLintBear:
+class PugLintBear:  # pragma nt: no cover
     """
     A configurable linter and style checker for ``Pug`` (formerly ``Jade``)
     that is a clean, whitespace-sensitive template language for writing HTML.

--- a/bears/r/FormatRBear.py
+++ b/bears/r/FormatRBear.py
@@ -10,7 +10,7 @@ from dependency_management.requirements.DistributionRequirement import (
     DistributionRequirement)
 
 
-def _map_to_r_bool(py_bool):
+def _map_to_r_bool(py_bool):  # pragma nt: no cover
     return 'TRUE' if py_bool else 'FALSE'
 
 
@@ -19,7 +19,7 @@ def _map_to_r_bool(py_bool):
         prerequisite_check_command=('Rscript', '-e', 'library(formatR)'),
         prerequisite_check_fail_message='Please install formatR for this bear '
                                         'to work.')
-class FormatRBear:
+class FormatRBear:  # pragma nt: no cover
     """
     Check and correct formatting of R Code using known formatR utility.
     """

--- a/bears/r/RLintBear.py
+++ b/bears/r/RLintBear.py
@@ -17,7 +17,7 @@ from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
                       'error': RESULT_SEVERITY.MAJOR},
         prerequisite_check_command=('Rscript', '-e', 'library(lintr)'),
         prerequisite_check_fail_message='R library "lintr" is not installed.')
-class RLintBear:
+class RLintBear:  # pragma nt: no cover
     """
     Checks the code with ``lintr``.
     """

--- a/bears/ruby/RuboCopBear.py
+++ b/bears/ruby/RuboCopBear.py
@@ -11,7 +11,7 @@ from coalib.results.Result import Result
 
 @linter(executable='rubocop',
         use_stdin=True)
-class RuboCopBear:
+class RuboCopBear:  # pragma nt: no cover
     """
     Check Ruby code for syntactic, formatting as well as semantic problems.
 

--- a/bears/ruby/RubyFastererBear.py
+++ b/bears/ruby/RubyFastererBear.py
@@ -5,7 +5,7 @@ from dependency_management.requirements.GemRequirement import GemRequirement
 @linter(executable='fasterer',
         output_format='regex',
         output_regex=r'(?P<message>.*\.).*:\s(?P<line>\d+)')
-class RubyFastererBear:
+class RubyFastererBear:  # pragma nt: no cover
     """
     The ``RubyFastererBear`` will suggest some speed improvements which you
     can check in details at the <https://github.com/JuanitoFatas/fast-ruby>.

--- a/bears/ruby/RubySecurityBear.py
+++ b/bears/ruby/RubySecurityBear.py
@@ -10,7 +10,7 @@ from dependency_management.requirements.GemRequirement import GemRequirement
 
 @linter(executable='brakeman',
         global_bear=True)
-class RubySecurityBear:
+class RubySecurityBear:  # pragma nt: no cover
     """
     Checks the Security issues of Ruby Applications.
 

--- a/bears/ruby/RubySmellBear.py
+++ b/bears/ruby/RubySmellBear.py
@@ -9,7 +9,7 @@ from coala_utils.param_conversion import negate
 
 
 @linter(executable='reek', use_stdin=True)
-class RubySmellBear:
+class RubySmellBear:  # pragma nt: no cover
     """
     Detect code smells in Ruby source code.
 

--- a/bears/scss/SASSLintBear.py
+++ b/bears/scss/SASSLintBear.py
@@ -8,7 +8,7 @@ from coalib.results.Result import Result
 
 
 @linter(executable='sass-lint')
-class SASSLintBear:
+class SASSLintBear:  # pragma nt: no cover
     """
     Check SCSS/SASS code to keep it clean and readable.
     """

--- a/bears/scss/SCSSLintBear.py
+++ b/bears/scss/SCSSLintBear.py
@@ -10,7 +10,7 @@ from dependency_management.requirements.PipRequirement import PipRequirement
         output_regex=r'.+:(?P<line>\d+):(?P<column>\d+)\s+'
                      r'\[(?P<severity>.)\]\s+'
                      r'(?P<message>.*)')
-class SCSSLintBear:
+class SCSSLintBear:  # pragma nt: no cover
     """
     Check SCSS code to keep it clean and readable.
 

--- a/bears/shell/ShellCheckBear.py
+++ b/bears/shell/ShellCheckBear.py
@@ -10,7 +10,7 @@ from dependency_management.requirements.CabalRequirement import (
 @linter(executable='shellcheck', output_format='regex',
         output_regex=r'.+:(?P<line>\d+):(?P<column>\d+): '
                      r'(?P<severity>error|warning|info): (?P<message>.+)')
-class ShellCheckBear:
+class ShellCheckBear:  # pragma nt: no cover
     """
     Check bash/shell scripts for syntactical problems (with understandable
     messages), semantical problems as well as subtle caveats and pitfalls.

--- a/bears/sql/SQLintBear.py
+++ b/bears/sql/SQLintBear.py
@@ -5,7 +5,7 @@ from dependency_management.requirements.GemRequirement import GemRequirement
 @linter(executable='sqlint', use_stdin=True, output_format='regex',
         output_regex=r'.+:(?P<line>\d+):(?P<column>\d+):'
                      r'(?P<severity>ERROR|WARNING) (?P<message>(?:\s*.+)*)')
-class SQLintBear:
+class SQLintBear:  # pragma nt: no cover
     """
     Check the given SQL files for syntax errors or warnings.
 

--- a/bears/stylus/StylintBear.py
+++ b/bears/stylus/StylintBear.py
@@ -14,7 +14,7 @@ _setting_map = {True: 'always',
         output_regex=r'(?P<line>\d+):?(?P<column>\d+)?\s+.*?'
                      r'(?P<severity>error|warning)\s+(?P<message>.+?)'
                      r'(?:  .*|\n|$)')
-class StylintBear:
+class StylintBear:  # pragma nt: no cover
     """
     Attempts to catch little mistakes (duplication of rules for instance) and
     enforces a code style guide on Stylus (a dynamic stylesheet language

--- a/bears/swift/TailorBear.py
+++ b/bears/swift/TailorBear.py
@@ -13,7 +13,7 @@ from dependency_management.requirements.DistributionRequirement import (
         prerequisite_check_command=('tailor', '-v'),
         prerequisite_check_fail_message='Tailor is not installed. Refer '
         'https://tailor.sh/ for installation details.')
-class TailorBear:
+class TailorBear:  # pragma nt: no cover
     """
     Analyze Swift code and check for code style related
     warning messages.

--- a/bears/typescript/TSLintBear.py
+++ b/bears/typescript/TSLintBear.py
@@ -7,7 +7,7 @@ from coalib.settings.Setting import path
 
 
 @linter(executable='tslint')
-class TSLintBear:
+class TSLintBear:  # pragma nt: no cover
     """
     Check TypeScript code for style violations and possible semantical
     problems.

--- a/bears/verilog/VerilogLintBear.py
+++ b/bears/verilog/VerilogLintBear.py
@@ -8,7 +8,7 @@ from dependency_management.requirements.DistributionRequirement import (
         use_stderr=True,
         output_regex=r'\%(?:(?P<severity>Error|Warning.*?).*?):'
                      r'.+?:(?P<line>.+?): (?P<message>.+)')
-class VerilogLintBear:
+class VerilogLintBear:  # pragma nt: no cover
     """
     Analyze Verilog code using ``verilator`` and checks for all lint
     related and code style related warning messages. It supports the

--- a/bears/vhdl/VHDLLintBear.py
+++ b/bears/vhdl/VHDLLintBear.py
@@ -8,7 +8,7 @@ from dependency_management.requirements.DistributionRequirement import (
 @linter(executable='perl',
         output_format='regex',
         output_regex=r'.+:(?P<line>\d+):(?P<severity>.*) - (?P<message>.*)')
-class VHDLLintBear:
+class VHDLLintBear:  # pragma nt: no cover
     """
     Check VHDL code for common codestyle problems.
 

--- a/bears/xml2/XMLBear.py
+++ b/bears/xml2/XMLBear.py
@@ -8,7 +8,7 @@ from coalib.settings.Setting import path, url
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 
-def path_or_url(xml_dtd):
+def path_or_url(xml_dtd):  # pragma nt: no cover
     """
     Converts the setting value to url or path.
 
@@ -24,7 +24,7 @@ def path_or_url(xml_dtd):
 @linter(executable='xmllint',
         use_stdout=True,
         use_stderr=True)
-class XMLBear:
+class XMLBear:  # pragma nt: no cover
     """
     Checks the code with ``xmllint``.
 

--- a/bears/yaml/RAMLLintBear.py
+++ b/bears/yaml/RAMLLintBear.py
@@ -6,7 +6,7 @@ from dependency_management.requirements.NpmRequirement import NpmRequirement
         output_format='regex',
         output_regex=r'(?P<severity>error|warning|info).*\n  (?P<message>.+) '
                      r'\[(?P<origin>.+)\]')
-class RAMLLintBear:
+class RAMLLintBear:  # pragma nt: no cover
     """
     RAML Linter is a static analysis, linter-like, utility that will enforce
     rules on a given RAML document, ensuring consistency and quality.

--- a/bears/yaml/TravisLintBear.py
+++ b/bears/yaml/TravisLintBear.py
@@ -8,7 +8,7 @@ from dependency_management.requirements.GemRequirement import GemRequirement
 @linter(executable='travis',
         output_format='regex',
         output_regex=r'\[x\]\s+(?P<message>.+)')
-class TravisLintBear:
+class TravisLintBear:  # pragma nt: no cover
     """
     A validator for your ``.travis.yml`` that attempts to reduce common build
     errors such as:

--- a/bears/yaml/YAMLLintBear.py
+++ b/bears/yaml/YAMLLintBear.py
@@ -10,7 +10,7 @@ import yaml
                      r'\[(?P<severity>error|warning)\] (?P<message>.+)',
         severity_map={'error': RESULT_SEVERITY.MAJOR,
                       'warning': RESULT_SEVERITY.NORMAL})
-class YAMLLintBear:
+class YAMLLintBear:  # pragma nt: no cover
     """
     Check yaml code for errors and possible problems.
 


### PR DESCRIPTION
This allows for 100% coverage on AppVeyor by
appending `# pragma nt: no cover` to places where
the Windows tests do not reach.

Closes https://github.com/coala/coala-bears/issues/1415

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
