### PR TITLE
reSTLintBear.py: Change rst_lint version

### DIFF
--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -31,7 +31,7 @@ pylint~=1.7.2
 pyroma~=2.2.0
 pyyaml~=3.12
 radon==1.4.0
-restructuredtext-lint~=1.0.0
+restructuredtext-lint~=1.0
 rstcheck~=3.1
 safety~=1.8.2
 scspell3k~=2.0

--- a/bear-requirements.yaml
+++ b/bear-requirements.yaml
@@ -204,7 +204,7 @@ pip_requirements:
   radon:
     version: ==1.4.0
   restructuredtext-lint:
-    version: ~=1.0.0
+    version: ~=1.0
   rstcheck:
     version: ~=3.1
   safety:

--- a/bears/rest/reSTLintBear.py
+++ b/bears/rest/reSTLintBear.py
@@ -8,7 +8,7 @@ from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 class reSTLintBear(LocalBear):
     LANGUAGES = {'reStructuredText'}
-    REQUIREMENTS = {PipRequirement('restructuredtext-lint', '1.0.0')}
+    REQUIREMENTS = {PipRequirement('restructuredtext-lint', '~=1.0')}
     AUTHORS = {'The coala developers'}
     AUTHORS_EMAILS = {'coala-devel@googlegroups.com'}
     LICENSE = 'AGPL-3.0'


### PR DESCRIPTION
This adds support for Sphinx prolog and epilog and other new
features by changing restructuredtext-lint version from '1.0.0'
to '1.0' in the files reSTLintBear.py, bear-requirements.txt
and bear-requirements.yaml. This is done by ensuring that
upgrading to versions '1.1.x' and '1.2.x' is also allowed.

Closes https://github.com/coala/coala-bears/issues/1954

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
