### PR TITLE
URLBear: Use library to extract links

### DIFF
--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -36,6 +36,7 @@ rstcheck~=3.1
 safety~=1.8.2
 scspell3k~=2.0
 sqlparse~=0.2.4
+urlextract==0.9
 vim-vint~=0.3.12,!=0.3.19
 vulture~=0.25.0
 yamllint~=1.12.0

--- a/bear-requirements.yaml
+++ b/bear-requirements.yaml
@@ -213,6 +213,8 @@ pip_requirements:
     version: ~=2.0
   sqlparse:
     version: ~=0.2.4
+  urlextract:
+    version: ==0.9
   vim-vint:
     version: ~=0.3.12,!=0.3.19
   vulture:

--- a/tests/general/InvalidLinkBearTest.py
+++ b/tests/general/InvalidLinkBearTest.py
@@ -360,7 +360,7 @@ class InvalidLinkBearTest(LocalBearTestHelper):
         """.splitlines()
 
         invalid_file = """
-        <ruleset name="test" xmlns="http://this.isa.namespace/ruleset/7.0.0"
+        <ruleset name="test" xmlns="http://im.a.namespace.com/ruleset/7.0.0"
         xmlns:xsi="http://this.is.another/kindof/namespace"
         xsi:schemaLocation="http://this.namespace.dosent/exists/7.0.0"
         xsi:schemaLocation="http://httpbin.com/404">""".splitlines()
@@ -370,8 +370,11 @@ class InvalidLinkBearTest(LocalBearTestHelper):
 
             self.check_validity(self.uut, valid_file)
 
+            # The 2nd and 3rd URLs are invalid because they have invalid TLD
+            # See function _download_tlds_list(self) in linked file below:
+            # https://github.com/lipoja/URLExtract/blob/master/urlextract.py
             self.check_line_result_count(self.uut, invalid_file,
-                                         [1, 1, 1, 1])
+                                         [1, 0, 0, 1])
 
         info_severity_file = """
         <ruleset name="test" xmlns="http://this.is.a.namespace/ruleset/7.0.0"
@@ -413,7 +416,7 @@ class InvalidLinkBearTest(LocalBearTestHelper):
         http://example.co.in/404""".splitlines()
 
         link_ignore_list = [
-                           'http://coalaisthebest.com/',
+                           'http://coalaisthebest.com',
                            'http://httpbin.org/status/4[0-9][0-9]',
                            'http://httpbin.org/status/410',
                            'http://httpbin.org/status/5[0-9][0-9]',
@@ -463,15 +466,15 @@ class InvalidLinkBearTest(LocalBearTestHelper):
 
             self.check_validity(self.uut, ['https://gitmate.io'])
             mock.assert_has_calls([
-                unittest.mock.call('https://facebook.com/', timeout=2,
+                unittest.mock.call('https://facebook.com', timeout=2,
                                    allow_redirects=False),
-                unittest.mock.call('https://google.com/',
+                unittest.mock.call('https://google.com',
                                    timeout=10, allow_redirects=False),
                 unittest.mock.call('https://coala.io/som/thingg/page/123',
                                    timeout=25, allow_redirects=False),
-                unittest.mock.call('https://facebook.com/', timeout=20,
+                unittest.mock.call('https://facebook.com', timeout=20,
                                    allow_redirects=False),
-                unittest.mock.call('https://google.com/',
+                unittest.mock.call('https://google.com',
                                    timeout=20, allow_redirects=False),
                 unittest.mock.call('https://coala.io/som/thingg/page/123',
                                    timeout=20, allow_redirects=False),

--- a/tests/general/URLBearTest.py
+++ b/tests/general/URLBearTest.py
@@ -37,6 +37,16 @@ class URLBearTest(unittest.TestCase):
                          [3, 'http://www.google.com/404',
                           LINK_CONTEXT.no_context])
 
+    def test_detect_pip_vcs_url_result(self):
+        valid_file = """
+        git+http://www.github.com/foo.git
+        """.splitlines()
+
+        result = get_results(self.uut, valid_file)
+        self.assertEqual(result[0].contents,
+                         [2, 'http://www.github.com/foo.git',
+                          LINK_CONTEXT.pip_vcs_url])
+
     def test_precentage_encoded_url(self):
         valid_file = """
         # A url with a precentage-encoded character in path
@@ -52,6 +62,42 @@ class URLBearTest(unittest.TestCase):
                               ('https://img.shields.io/badge/Maintained%3F-'
                                'yes-green.svg/200'),
                               LINK_CONTEXT.no_context])
+
+    def test_detect_enclosed_parenthesis_url_result(self):
+        valid_file = """
+        http://wik.org/Hello_(Adele_song)/200
+        """.splitlines()
+
+        result = get_results(self.uut, valid_file)
+        self.assertEqual(result[0].contents,
+                         [2, 'http://wik.org/Hello_(Adele_song)/200',
+                          LINK_CONTEXT.no_context])
+
+    def test_detect_trailing_char_url_result(self):
+        valid_file = """
+        http://google.com/trailing.
+        """.splitlines()
+
+        result = get_results(self.uut, valid_file)
+        self.assertEqual(result[0].contents,
+                         [2, 'http://google.com/trailing',
+                          LINK_CONTEXT.no_context])
+
+    def test_detect_example_url_result(self):
+        invalid_file = """
+        http://example.com
+        """.splitlines()
+
+        result = get_results(self.uut, invalid_file)
+        self.assertEqual(result, [])
+
+    def test_detect_no_scheme_url_result(self):
+        invalid_file = """
+        foo.com
+        """.splitlines()
+
+        result = get_results(self.uut, invalid_file)
+        self.assertEqual(result, [])
 
 
 class URLResultTest(unittest.TestCase):


### PR DESCRIPTION
This replaces the use of regex for extracting
links with the use of the URLExtract library.

Closes https://github.com/coala/coala-bears/issues/1342

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [ ] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [ ] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
