### PR TITLE
README.rst: Update FAQ link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ To also install all bears for coala at once, run:
 
 Be sure to use the latest version of pip, the default pip from Debian doesn't
 support our dependency version number specifiers. You will have to `use a
-virtualenv <https://github.com/coala/coala/wiki/FAQ#installation-is-failing-help>`__
+virtualenv <http://docs.coala.io/en/latest/Help/FAQ.html#installation-is-failing-help>`__
 in this case.
 
 |PyPI| |Windows| |Linux|


### PR DESCRIPTION
This change in Installation section of README.rst helps the user to directly jump to the actual FAQ page than the redirection page.

Closes https://github.com/coala/coala-bears/issues/2821