### PR TITLE
Update URLHeadBear.py.

### DIFF
--- a/bears/general/URLHeadBear.py
+++ b/bears/general/URLHeadBear.py
@@ -70,7 +70,7 @@ class URLHeadBear(LocalBear):
     CAN_DETECT = {'Documentation'}
 
     # IP Address of www.google.com
-    check_connection_url = 'http://216.58.218.174'
+    check_connection_url = 'https://1.1.1.1/'
 
     @classmethod
     def check_prerequisites(cls):


### PR DESCRIPTION
The default URL currently being used to check for internet connectivity, http://216.58.218.174 
appears to be broken. The HEAD request to this URL fails and hence the InvalidLinkBear, throwing an error [ERROR][14:16:23] The bear InvalidLinkBear does not fulfill all requirements. You are not connected to the internet.URL can be changed to 1.1.1.1 DNS IP by Cloudflare.


