### PR TITLE
URLHeadBear.py: Change connection check URL

### DIFF
--- a/bears/general/URLHeadBear.py
+++ b/bears/general/URLHeadBear.py
@@ -69,8 +69,8 @@ class URLHeadBear(LocalBear):
     LICENSE = 'AGPL-3.0'
     CAN_DETECT = {'Documentation'}
 
-    # IP Address of www.google.com
-    check_connection_url = 'http://216.58.218.174'
+    # DNS IP by Cloudfare
+    check_connection_url = 'https://1.1.1.1/'
 
     @classmethod
     def check_prerequisites(cls):

--- a/tests/general/URLHeadBearTest.py
+++ b/tests/general/URLHeadBearTest.py
@@ -15,8 +15,9 @@ class URLHeadBearTestPrerequisites(unittest.TestCase):
     def test_check_prerequisites(self):
         with requests_mock.Mocker() as m:
             m.add_matcher(custom_matcher)
-            self.assertEqual(URLHeadBear.check_prerequisites(),
-                             'You are not connected to the internet.')
+            self.assertTrue(URLHeadBear.check_prerequisites())
+            self.assertNotEqual(URLHeadBear.check_prerequisites(),
+                                'You are not connected to the internet.')
 
             m.head(URLHeadBear.check_connection_url,
                    exc=requests.exceptions.RequestException)


### PR DESCRIPTION
Changed URL that checks if client is connected to the internet or not
from Google's IP address 216.58.218.174
to DNS IP owned by Cloudfare 1.1.1.1

Fixes https://github.com/coala/coala-bears/issues/2833

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
