### PR TITLE
CI: Fix Pycodestyle warning W605

### DIFF
--- a/bears/c_languages/codeclone_detection/ClangCountingConditions.py
+++ b/bears/c_languages/codeclone_detection/ClangCountingConditions.py
@@ -245,8 +245,8 @@ def in_sum(stack):  # pragma nt: no cover
 def in_product(stack):  # pragma nt: no cover
     """
     A counting condition returning true if the variable is used in a product
-    statement, i.e. within the operators \*, /, % and their associated compound
-    operators.
+    statement, i.e. within the operators \\*, /, % and their associated
+    compound operators.
     """
     return _stack_contains_operators(stack, ['*', '/', '%', '*=', '/=', '%='])
 
@@ -254,8 +254,8 @@ def in_product(stack):  # pragma nt: no cover
 def in_binary_operation(stack):  # pragma nt: no cover
     """
     A counting condition returning true if the variable is used in a binary
-    operation, i.e. within the operators \|, & and their associated compound
-    operators.
+    operation, i.e. within the operators \\|, & and their associated
+    compound operators.
     """
     return _stack_contains_operators(stack, ['&', '|', '&=', '|='])
 

--- a/bears/vcs/git/GitCommitBear.py
+++ b/bears/vcs/git/GitCommitBear.py
@@ -35,7 +35,7 @@ class GitCommitBear(_CommitBear):
         """
         This function creates a git command to fetch the
         unmerged parent commit shortlog from a commit generated
-        by GitHub in a refs/pull/(\d+)/merge git remote reference.
+        by GitHub in a refs/pull/(\\d+)/merge git remote reference.
         Visit https://github.com/travis-ci/travis-ci/issues/8400
         for more details.
 


### PR DESCRIPTION
W605 is a warning for invalid escape sequences.

In python 3.6, Unknown escapes consisting of `\` and an ASCII letter in regular expressions will
cause an warning.In the upcoming python versions this would be treated as an error.
Owing to it pycodestyle have added this check for future Python versions.

The alternative way to escape special characters now is to append a extra `\` infront of the
sequences. Escape the characters by double backticks.

Fixes https://github.com/coala/coala-bears/issues/2760

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
