### PR TITLE
PySafetyBear.py: Add proxy positional argument

### DIFF
--- a/bears/python/requirements/PySafetyBear.py
+++ b/bears/python/requirements/PySafetyBear.py
@@ -94,7 +94,7 @@ class PySafetyBear(LocalBear):
 
         for vulnerability in safety.check(packages, key=None,
                                           db_mirror=db_path, cached=False,
-                                          ignore_ids=cve_ignore):
+                                          ignore_ids=cve_ignore, proxy=None):
             if 'cve' in vulnerability.vuln_id.strip().lower():
                 message_template = (
                     '{vuln.name}{vuln.spec} is vulnerable to {vuln.vuln_id} '

--- a/tests/python/requirements/PySafetyBearTest.py
+++ b/tests/python/requirements/PySafetyBearTest.py
@@ -31,7 +31,8 @@ class PySafetyBearTest(LocalBearTestHelper):
             self.check_validity(self.uut, ['# whee', 'foo==1.0', '# whee'])
             check.assert_called_once_with([Package('foo', '1.0')], key=None,
                                           db_mirror=self.uut.db_path,
-                                          cached=False, ignore_ids=[])
+                                          cached=False, ignore_ids=[],
+                                          proxy=None)
 
     def test_with_vulnerability(self):
         with mock.patch(
@@ -41,7 +42,8 @@ class PySafetyBearTest(LocalBearTestHelper):
             self.check_invalidity(self.uut, ['foo<2', 'bar==0.1', '**bar'])
             check.assert_called_once_with([Package('bar', '0.1')], key=None,
                                           db_mirror=self.uut.db_path,
-                                          cached=False, ignore_ids=[])
+                                          cached=False, ignore_ids=[],
+                                          proxy=None)
 
     def test_with_no_requirements(self):
         with mock.patch(


### PR DESCRIPTION
The newer Safety package(v1.8.5) now adds the
functionality to support proxies which the Requests
package of Python uses.

The above functionality by Safety has been provided
by adding an extra positional argument called `proxy`
in the `saftey.check()` function. This caused the
TypeError in the previous version of Safety,due to
mismatch of number of positional argument

Closes https://github.com/coala/coala-bears/issues/2857

<!--
Thanks for your contribution!

Please take a quick look at those things down there. They're quite important.
Really! We wrote them for you. Yes you! With utmost care. Read them.
-->

**For short term contributors:** we understand that getting your commits well
defined like we require is a hard task and takes some learning. If you
look to help without wanting to contribute long term there's no need
for you to learn this. Just drop us a message and we'll take care of brushing
up your stuff for merge!

### Checklist

- [x] I read the [commit guidelines](http://coala.io/commit) and I've followed
      them.
- [x] I ran coala over my code locally. (*All commits have to pass
      individually.* It is not sufficient to have "fixup commits" on your PR,
      our bot will still report the issues for the previous commit.) You will
      likely receive a lot of bot comments and build failures if coala does not
      pass on every single commit!

After you submit your pull request, **DO NOT click the 'Update Branch' button.**
When asked for a rebase, consult [coala.io/rebase](https://coala.io/rebase)
instead.

Please consider helping us by reviewing other peoples pull requests as well:

- pick up any PR at <https://coala.io/review>
- review it (check <https://coala.io/reviewing> for more info)
- if you are sure that it needs work, use `corobo mark wip <URL>` to get it out
  of the review queue.

The more you review, the more your score will grow at coala.io and we will
review your PRs faster!
