### PR TITLE
Replace dep munkres3 with munkres

### DIFF
--- a/bear-requirements.txt
+++ b/bear-requirements.txt
@@ -19,7 +19,7 @@ language-check~=1.0
 libclang-py3~=3.4.0
 lxml>=1.0
 memento-client~=0.6.1
-munkres3~=1.0
+munkres~=1.1.2
 mypy==0.590
 nbformat~=4.1
 nltk~=3.2

--- a/bear-requirements.yaml
+++ b/bear-requirements.yaml
@@ -44,8 +44,8 @@ pip_requirements:
     version: '>=1.0'
   memento-client:
     version: ~=0.6.1
-  munkres3:
-    version: ~=1.0
+  munkres:
+    version: ~=1.1.2
   mypy:
     version: ==0.590
   nbformat:

--- a/bears/c_languages/codeclone_detection/ClangFunctionDifferenceBear.py
+++ b/bears/c_languages/codeclone_detection/ClangFunctionDifferenceBear.py
@@ -107,7 +107,7 @@ def get_difference(function_pair,
 class ClangFunctionDifferenceBear(GlobalBear):
     check_prerequisites = classmethod(clang_available)
     LANGUAGES = ClangBear.LANGUAGES
-    REQUIREMENTS = ClangBear.REQUIREMENTS | {PipRequirement('munkres3', '1.0')}
+    REQUIREMENTS = ClangBear.REQUIREMENTS | {PipRequirement('munkres', '1.1.2')}
 
     def run(self,
             counting_conditions: counting_condition_dict = default_cc_dict,


### PR DESCRIPTION
The official [munkres](https://github.com/bmc/munkres) now supports Python3, so
we don't need to use [munkres3](https://github.com/datapublica/munkres).

Closes #2871 