### PR TITLE
generate_bear_requirements.py: Add Perl Metadata

### DIFF
--- a/.ci/generate_bear_requirements.py
+++ b/.ci/generate_bear_requirements.py
@@ -51,6 +51,7 @@ SUPPORTED_INSTANCES = (
     'ComposerRequirement',
     'CabalRequirement',
     'RscriptRequirement',
+    'PerlRequirement',
 )
 
 INSTANCE_NAMES = (
@@ -60,6 +61,7 @@ INSTANCE_NAMES = (
     'composer_requirements',
     'cabal_requirements',
     'r_script_requirements',
+    'perl_requirements'
 )
 
 
@@ -174,6 +176,8 @@ def get_pip_requirements(requirements):
 def get_cabal_requirements(requirements):
     return _get_requirements(requirements, '==')
 
+def get_perl_requirements(requirements):
+    return _get_requirements(requirements, '==')
 
 def _create_sorted_commented_map(input_dict):
     return CommentedMap(sorted(input_dict.items(),
@@ -266,6 +270,8 @@ if __name__ == '__main__':
                                             instance_dict['ComposerRequirement'])
     requirements['cabal_requirements'] = get_cabal_requirements(
                                             instance_dict['CabalRequirement'])
+    requirements['perl_requirements'] = get_perl_requirements(
+                                            instance_dict['PerlRequirement'])
 
     if args.update or args.check:
         input_file_path = os.path.join(PROJECT_DIR, BEAR_REQUIREMENTS_YAML)

--- a/.moban.dt/Makefile.PL.jj2
+++ b/.moban.dt/Makefile.PL.jj2
@@ -1,0 +1,6 @@
+use ExtUtils::MakeMaker;
+WriteMakefile(
+    NAME              => 'Coala::Bears',
+    VERSION           => '0.10',
+    PREREQ_PM         => {Perl::Critic => 1.126},
+);

--- a/.moban.yaml
+++ b/.moban.yaml
@@ -41,6 +41,7 @@ targets:
   - runtime.txt: runtime.txt
   - netlify.toml: docs/netlify.toml
   - coala-bears.cabal: coala-bears.cabal.jj2
+  - Makefile.PL: Makefile.PL.jj2
 copy:
   - .ci/check_moban.sh: ci/check_moban.sh
   - .ci/check_setuptools.py: ci/check_setuptools.py

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,6 @@
+use ExtUtils::MakeMaker;
+WriteMakefile(
+    NAME              => 'Coala::Bears',
+    VERSION           => '0.10',
+    PREREQ_PM         => {Perl::Critic => 1.126},
+);

--- a/bear-requirements.yaml
+++ b/bear-requirements.yaml
@@ -233,3 +233,4 @@ cabal_requirements:
     version: ==5.6.0.0
   hlint:
     version: ==1.9.27
+perl_requirements: {}

--- a/bears/perl/PerlCriticBear.py
+++ b/bears/perl/PerlCriticBear.py
@@ -1,6 +1,10 @@
 from coalib.bearlib.abstractions.Linter import linter
 from dependency_management.requirements.DistributionRequirement import (
     DistributionRequirement)
+from dependency_management.requirements.AnyOneOfRequirements import (
+    AnyOneOfRequirements)
+from dependency_managment.requirements.PerlRequirement import (
+    PerlRequirement)
 from coalib.results.RESULT_SEVERITY import RESULT_SEVERITY
 
 
@@ -24,14 +28,18 @@ class PerlCriticBear:
 
     LANGUAGES = {'Perl'}
     REQUIREMENTS = {
-        DistributionRequirement(
-            apt_get='libperl-critic-perl',
-            brew=None,
-            dnf='perl-Perl-Critic',
-            portage='dev-perl/Perl-Critic',
-            xbps=None,
-            yum='perl-Perl-Critic',
-            zypper='perl-Perl-Critic',
+        AnyOneOfRequirements(
+            [PerlRequirement(package='Critic',version='==1.126'),
+             DistributionRequirement(
+                apt_get='libperl-critic-perl',
+                brew=None,
+                dnf='perl-Perl-Critic',
+                portage='dev-perl/Perl-Critic',
+                xbps=None,
+                yum='perl-Perl-Critic',
+                zypper='perl-Perl-Critic',
+                ), 
+            ],
         ),
     }
     AUTHORS = {'The coala developers'}


### PR DESCRIPTION
This enhances generate_bear_requirements.py to support
perl bears and generate Makefile.PL using jinja2
template.
closes https://github.com/coala/coala-bears/issues/2483
