### PR TITLE
HTMLLintBear: Enable use_spaces by default

### DIFF
--- a/bears/hypertext/HTMLLintBear.py
+++ b/bears/hypertext/HTMLLintBear.py
@@ -27,7 +27,7 @@ class HTMLLintBear:
     CAN_DETECT = {'Syntax', 'Formatting'}
 
     @staticmethod
-    def create_arguments(filename, file, config_file, use_spaces: bool,
+    def create_arguments(filename, file, config_file, use_spaces: bool = True,
                          htmllint_ignore: typed_list(str) = [],
                          ):
         """


### PR DESCRIPTION
This restores prior behaviour.

Fixes https://github.com/coala/coala-bears/issues/2949