### PR TITLE
Add image link for Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,3 +184,4 @@ License
 .. |Throughput Graph| image:: https://graphs.waffle.io/coala/coala-bears/throughput.svg
    :target: https://waffle.io/coala/coala-bears/metrics/throughput
    :alt: 'Throughput Graph'
+.. |Linux| image:: https://img.shields.io/badge/platform-Linux-brightgreen.svg


### PR DESCRIPTION
readme.rst: Add image link for Linux

This fixes adding a missing image link for Linux
+.. |Linux| image:: https://img.shields.io/badge/platform-Linux-brightgreen.sv